### PR TITLE
Fix GameConqueror hanging and Python 3 support

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -936,7 +936,7 @@ class GameConqueror():
                 row = self.scanresult_liststore[i]
                 addr, cur_value, scanmem_type, valid, off, rtype = row
                 if valid:
-                    new_value = self.read_value(addr, TYPENAMES_S2G[scanmem_type.strip()], cur_value)
+                    new_value = self.read_value(addr, TYPENAMES_S2G[scanmem_type.split(' ', 1)[0]], cur_value)
                     if new_value is not None:
                         row[1] = str(new_value)
                     else:

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -933,7 +933,7 @@ class GameConqueror():
             rows = self.get_visible_rows(self.scanresult_tv)
             for i in rows:
                 row = self.scanresult_liststore[i]
-                addr, cur_value, scanmem_type, valid = row
+                addr, cur_value, scanmem_type, valid, off, rtype = row
                 if valid:
                     new_value = self.read_value(addr, TYPENAMES_S2G[scanmem_type.strip()], cur_value)
                     if new_value is not None:

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -905,6 +905,7 @@ class GameConqueror():
             # temporarily disable model for scanresult_liststore for the sake of performance
             self.scanresult_liststore.clear()
             for line in lines:
+                line = str(line)
                 line = line[line.find(']')+1:]
                 (a, o, rt, v, t) = list(map(str.strip, line.split(',')[:5]))
                 a = '%x'%(int(a,16),)

--- a/gui/backend.py
+++ b/gui/backend.py
@@ -57,14 +57,14 @@ class GameConquerorBackend():
                 backup_stdout_fileno = os.dup(sys.stdout.fileno())
                 os.dup2(directed_file.fileno(), sys.stdout.fileno())
 
-                self.lib.backend_exec_cmd(ctypes.c_char_p(cmd))
+                self.lib.backend_exec_cmd(ctypes.c_char_p(cmd.encode()))
 
                 os.dup2(backup_stdout_fileno, sys.stdout.fileno())
                 os.close(backup_stdout_fileno)
                 directed_file.seek(0)
                 return directed_file.readlines()
         else:
-            self.lib.backend_exec_cmd(ctypes.c_char_p(cmd))
+            self.lib.backend_exec_cmd(ctypes.c_char_p(cmd.encode()))
 
     def get_match_count(self):
         return self.lib.get_num_matches()

--- a/gui/backend.py
+++ b/gui/backend.py
@@ -70,7 +70,7 @@ class GameConquerorBackend():
         return self.lib.get_num_matches()
 
     def get_version(self):
-        return self.lib.get_version()
+        return self.lib.get_version().decode("utf-8")
 
     def get_scan_progress(self):
         return self.lib.get_scan_progress()

--- a/gui/misc.py
+++ b/gui/misc.py
@@ -88,7 +88,7 @@ def check_scan_command (data_type, cmd, is_first_scan):
 def eval_operand(s):
     try:
         v = eval(s)
-        if isinstance(v, (int,long,float)):
+        if isinstance(v, int) or isinstance(v, long) or isinstance(v, float):
             return v
     except:
         pass


### PR DESCRIPTION
The first commit is the most important one. My own commit aedf069 ("gui: add match offset and region type support") didn't catch all code locations to be modified so that GC is hanging when searching in scan results. Sorry for that!
All other fixes are Python 3 fixes. I've tested them against Python 3.4 and 2.7. I've used the int32 lives value of the HeroAircraft object of the game Chromium B.S.U. to test this. I've frozen the lives to 9 to check if GC does the right thing.