### PR TITLE
debian, autogen: fix the Debian package build with sbuild

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-libtoolize && aclocal -I m4 && automake --add-missing && autoconf && intltoolize -f
+libtoolize -c && aclocal -I m4 && automake -c --add-missing && autoconf && intltoolize -f -c

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,18 @@ Source: scanmem
 Section: utils
 Priority: extra
 Maintainer: WANG Lu <coolwanglu@gmail.com>
-Build-Depends: debhelper (>= 8), autotools-dev, automake, libreadline-dev, libtool, intltool
+Build-Depends: automake,
+               autotools-dev,
+               debhelper (>= 8),
+               intltool,
+               libreadline-dev,
+               libtool
 Standards-Version: 3.9.3
 Homepage: http://code.google.com/p/scanmem/
 
 Package: scanmem
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${misc:Depends}, ${shlibs:Depends}
 Suggests: gameconqueror (>= 0.14)
 Description: Program to locate and modify a variable in a running process
  Scanmem is a simple interactive debugging utility for Linux, used to locate
@@ -18,7 +23,12 @@ Description: Program to locate and modify a variable in a running process
 
 Package: gameconqueror
 Architecture: all
-Depends: ${misc:Depends}, policykit-1, python, python-gi, gir1.2-gtk-3.0, scanmem (>= 0.14)
+Depends: gir1.2-gtk-3.0,
+         policykit-1,
+         python,
+         python-gi,
+         scanmem (>= 0.14),
+         ${misc:Depends}
 Description: GUI for scanmem, a game hacking tool
  Scanmem is a simple interactive debugging utility for Linux, used to locate
  the address of a variable in a running process. This can be used for the
@@ -27,4 +37,3 @@ Description: GUI for scanmem, a game hacking tool
  .
  GameConqueror is a GUI for scanmem, aims to provide more features than
  scanmem, and CheatEngline-alike user-friendly interface.
-

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: scanmem
 Section: utils
 Priority: extra
 Maintainer: WANG Lu <coolwanglu@gmail.com>
-Build-Depends: debhelper (>= 8), autotools-dev, libreadline-dev, libtool, intltool
+Build-Depends: debhelper (>= 8), autotools-dev, automake, libreadline-dev, libtool, intltool
 Standards-Version: 3.9.3
 Homepage: http://code.google.com/p/scanmem/
 

--- a/debian/gameconqueror.install
+++ b/debian/gameconqueror.install
@@ -1,5 +1,6 @@
 usr/bin/gameconqueror
 usr/share/applications/GameConqueror.desktop
-usr/share/pixmaps/GameConqueror*
+gui/GameConqueror_128x128.png usr/share/pixmaps/GameConqueror_128x128.png
+gui/GameConqueror_72x72.png usr/share/pixmaps/GameConqueror_72x72.png
 usr/share/gameconqueror/*
 usr/share/locale/*/LC_MESSAGES/GameConqueror.mo

--- a/debian/gameconqueror.install
+++ b/debian/gameconqueror.install
@@ -1,6 +1,6 @@
-usr/bin/gameconqueror
-usr/share/applications/GameConqueror.desktop
 gui/GameConqueror_128x128.png usr/share/pixmaps/GameConqueror_128x128.png
 gui/GameConqueror_72x72.png usr/share/pixmaps/GameConqueror_72x72.png
+usr/bin/gameconqueror
+usr/share/applications/GameConqueror.desktop
 usr/share/gameconqueror/*
 usr/share/locale/*/LC_MESSAGES/GameConqueror.mo

--- a/debian/source/format
+++ b/debian/source/format
@@ -1,1 +1,1 @@
-3.0 (quilt)
+3.0 (native)


### PR DESCRIPTION
Using sbuild to build Debian packages in a chroot environment is quite common. I'm using a Debian Wheezy chroot environment and noticed several issues. This patch set fixes them all.