### PR TITLE
fix endianness check

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -1,5 +1,8 @@
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
+/* Define if building universal (internal helper macro) */
+#undef AC_APPLE_UNIVERSAL_BUILD
+
 /* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
    systems. This function is required for `alloca.c' support on those systems.
    */
@@ -161,6 +164,18 @@
 
 /* Version number of package */
 #undef VERSION
+
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+   significant byte first (like Motorola and SPARC, unlike Intel). */
+#if defined AC_APPLE_UNIVERSAL_BUILD
+# if defined __BIG_ENDIAN__
+#  define WORDS_BIGENDIAN 1
+# endif
+#else
+# ifndef WORDS_BIGENDIAN
+#  undef WORDS_BIGENDIAN
+# endif
+#endif
 
 /* Enable large inode numbers on Mac OS X 10.5.  */
 #ifndef _DARWIN_USE_64_BIT_INODE

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,8 @@ AC_TYPE_PID_T
 AC_TYPE_SIZE_T
 AC_TYPE_SSIZE_T
 
+AC_C_BIGENDIAN
+
 
 # check if termcap is present, sometimes required by readline
 AC_CHECK_LIB([termcap], [tgetent], [], [])

--- a/endianness.h
+++ b/endianness.h
@@ -24,10 +24,14 @@
 
 #include "scanmem.h"
 #include "value.h"
+#include "config.h"
 
-static const union { short x; char y; } endiantest = { .x = 0xabcd };
-// True iff host is big endian
-static const bool big_endian = endiantest.y == 0xab;
+/* True if host is big endian */
+#ifdef WORDS_BIGENDIAN
+static const bool big_endian = true;
+#else
+static const bool big_endian = false;
+#endif
 
 void fix_endianness(globals_t *vars, value_t *data_value);
 void swap_bytes_var(void *p, size_t num);


### PR DESCRIPTION
Commit 944a54a0 ("Configurable endianness of data") breaks the build on some systems due to non-standard endianness detection. So replace that with AC_C_BIGENDIAN added to configure.ac and a check if this defines WORDS_BIGENDIAN.

Tested on x86, x86_64 and in a Debian Wheezy ppc QEMU VM by adding "#warning big endian detected" to the "big_endian = true" case.

Fixes: Github issue #88 