### PR TITLE
Libless

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,11 @@ libscanmem_la_SOURCES = commands.h \
     value.h \
     value.c 
 
+if ENABLE_LIBLESS
+  libscanmem_la_SOURCES += libreplacements.h \
+      libreplacements.c
+endif
+
 libscanmem_la_LDFLAGS = -version-info 1:0:0
 
 bin_PROGRAMS = scanmem

--- a/README
+++ b/README
@@ -25,7 +25,12 @@ To build with gui:
     ./configure --prefix=/usr --enable-gui && make    
     sudo make install
 
-To build without gui:
+To build without library features:
+
+    ./configure --prefix=/usr --enable-libless && make
+    sudo make install
+
+To build without gui, and with library features:
 
     ./configure --prefix=/usr && make
     sudo make install

--- a/commands.c
+++ b/commands.c
@@ -35,7 +35,9 @@
 #include <stdbool.h>
 #include <ctype.h>
 
+#if defined (HAVE_LIBREADLINE) && (HAVE_LIBREADLINE != 0)
 #include <readline/readline.h>
+#endif
 
 #include "commands.h"
 #include "show_message.h"

--- a/configure.ac
+++ b/configure.ac
@@ -36,16 +36,6 @@ AC_TYPE_SSIZE_T
 AC_C_BIGENDIAN
 
 
-# check if termcap is present, sometimes required by readline
-AC_CHECK_LIB([termcap], [tgetent], [], [])
-
-# check for libreadline
-AC_CHECK_LIB([readline], [readline], [], [
-    echo "libreadline could not be found, which is required to continue."
-    echo "The libreadline-dev package may be required."
-    exit 1
-])
-
 # also need to check if the file is zero'ed (some hardened systems)
 AC_CHECK_FILE([/proc/self/maps], [], [
     echo "This system does not seem to have /proc/pid/maps files."
@@ -134,5 +124,24 @@ AC_ARG_ENABLE(gui, [AS_HELP_STRING([--enable-gui],
                  [enable_gui=false]
                  )
 
+# Check for termcap and readline, or bypass checking for the library.
+AC_ARG_ENABLE([libless], [AS_HELP_STRING([--enable-libless],
+                            [enable bypassing libreadline, with less features])],
+                 [enable_libless=true
+                 echo "Bypassing library linking (--enable-libless)."
+                 AC_DEFINE(HAVE_LIBTERMCAP, [0], [Define to 1 if you have the 'termcap' library (-ltermcap)])
+                 AC_DEFINE(HAVE_LIBREADLINE, [0], [Define to 1 if you have the 'readline' library (-lreadline)])
+                 ],
+                 [enable_libless=false
+                 echo "Using libraries, if available."
+                 AC_CHECK_LIB([termcap], [tgetent], [], [])
+                 AC_CHECK_LIB([readline], [readline], [], [
+                     echo "libreadline could not be found, which is required to continue."
+                     echo "The libreadline-dev package may be required."
+                     exit 1
+                     ])
+                 ])
+
 AM_CONDITIONAL([ENABLE_GUI], [test x$enable_gui = xtrue])
+AM_CONDITIONAL([ENABLE_LIBLESS], [test x$enable_libless = xtrue])
 AC_OUTPUT

--- a/handlers.c
+++ b/handlers.c
@@ -44,7 +44,12 @@
 #include <errno.h>
 #include <inttypes.h>
 
+// isprint without readline is in ctype
+#if defined (HAVE_LIBREADLINE) && (HAVE_LIBREADLINE != 0)
 #include <readline/readline.h>
+#else
+#include <ctype.h>
+#endif
 
 #include "commands.h"
 #include "endianness.h"

--- a/libreplacements.c
+++ b/libreplacements.c
@@ -1,0 +1,58 @@
+/*
+    libreplacements.c  Minimal function replacements for libraries. 
+    Copyright (C) 2015 Jonathan Pelletier <funmungus(a)gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+
+#include "libreplacements.h"
+
+int rl_attempted_completion_over = 0;
+const char *rl_readline_name = "scanmem";
+rl_completion_func_t *rl_attempted_completion_function = NULL;
+
+char **
+rl_completion_matches(text, entry_function)
+    const char *text;
+    rl_compentry_func_t *entry_function;
+{
+    (void) text;
+    (void) entry_function;
+    return 0;
+}
+
+char *
+readline(prompt)
+    const char *prompt;
+{
+    printf("%s", prompt);
+    fflush(stdout); /* otherwise front-end may not receive this */
+    char *line = NULL; /* let getline malloc it */
+    size_t n = 0;
+    ssize_t bytes_read = getline(&line, &n, stdin);
+    int success = (bytes_read > 0);
+    if (success)
+        line[bytes_read-1] = '\0'; /* remove the trialing newline */
+
+    return line;
+}
+
+void add_history(line)
+    const char *line;
+{
+    (void) line;
+}
+

--- a/libreplacements.c
+++ b/libreplacements.c
@@ -38,12 +38,15 @@ char *
 readline(prompt)
     const char *prompt;
 {
-    printf("%s", prompt);
-    fflush(stdout); /* otherwise front-end may not receive this */
     char *line = NULL; /* let getline malloc it */
     size_t n = 0;
-    ssize_t bytes_read = getline(&line, &n, stdin);
-    int success = (bytes_read > 0);
+    ssize_t bytes_read ;
+    int success ;
+
+    printf("%s", prompt);
+    fflush(stdout); /* otherwise front-end may not receive this */
+    bytes_read = getline(&line, &n, stdin);
+    success = (bytes_read > 0);
     if (success)
         line[bytes_read-1] = '\0'; /* remove the trialing newline */
 

--- a/libreplacements.h
+++ b/libreplacements.h
@@ -1,0 +1,34 @@
+/*
+    libreplacements.h  Minimal function replacements for libraries. 
+    Copyright (C) 2015 Jonathan Pelletier <funmungus(a)gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if !defined (LIBREPLACEMENTS_H)
+#define LIBREPLACEMENTS_H
+
+typedef char *rl_compentry_func_t(const char *, int);
+typedef char **rl_completion_func_t(const char *, int, int);
+
+extern int rl_attempted_completion_over;
+extern const char *rl_readline_name;
+extern rl_completion_func_t *rl_attempted_completion_function;
+
+extern char **rl_completion_matches(const char *, rl_compentry_func_t *);
+extern char *readline(const char *);
+extern void add_history(const char *);
+
+#endif
+

--- a/menu.c
+++ b/menu.c
@@ -32,8 +32,12 @@
 #include <string.h>
 #include <stdbool.h>
 
+#if defined (HAVE_LIBREADLINE) && (HAVE_LIBREADLINE != 0)
 #include <readline/readline.h>
 #include <readline/history.h>
+#else
+#include "libreplacements.h"
+#endif
 
 #include "scanmem.h"
 #include "commands.h"


### PR DESCRIPTION
Enable bypassing library linking with --enable-libless option in configure script.  This will allow building without libraries, but less features will be available.
libreplacements implements missing functions.

To build, `./configure --prefix=/usr --enable-libless && make`
