### PR TITLE
Libless

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -33,6 +33,11 @@ libscanmem_la_SOURCES = commands.h \
     value.h \
     value.c 
 
+if ENABLE_LIBLESS
+  libscanmem_la_SOURCES += libreplacements.h \
+      libreplacements.c
+endif
+
 libscanmem_la_LDFLAGS = -version-info 1:0:0
 
 bin_PROGRAMS = scanmem

--- a/README
+++ b/README
@@ -30,6 +30,11 @@ To build without gui:
     ./configure --prefix=/usr && make
     sudo make install
 
+To build without gui and without library features:
+
+    ./configure --prefix=/usr --enable-libless && make
+    sudo make install
+
 If you want to specify a prefix other than '/usr', make sure that <prefix>/lib is in the
 LD_LIBRARY_PATH for root
 

--- a/commands.c
+++ b/commands.c
@@ -35,8 +35,6 @@
 #include <stdbool.h>
 #include <ctype.h>
 
-#include <readline/readline.h>
-
 #include "commands.h"
 #include "show_message.h"
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,16 +36,6 @@ AC_TYPE_SSIZE_T
 AC_C_BIGENDIAN
 
 
-# check if termcap is present, sometimes required by readline
-AC_CHECK_LIB([termcap], [tgetent], [], [])
-
-# check for libreadline
-AC_CHECK_LIB([readline], [readline], [], [
-    echo "libreadline could not be found, which is required to continue."
-    echo "The libreadline-dev package may be required."
-    exit 1
-])
-
 # also need to check if the file is zero'ed (some hardened systems)
 AC_CHECK_FILE([/proc/self/maps], [], [
     echo "This system does not seem to have /proc/pid/maps files."
@@ -134,5 +124,27 @@ AC_ARG_ENABLE(gui, [AS_HELP_STRING([--enable-gui],
                  [enable_gui=false]
                  )
 
+# Check for termcap and readline or bypass checking for the libraries.
+AC_ARG_ENABLE([libless], [AS_HELP_STRING([--enable-libless],
+                            [use a libreadline replacement with less features])],
+                 [enable_libless=true
+                 echo "Bypassing library linking (--enable-libless)."
+                 AC_DEFINE(HAVE_LIBTERMCAP, [0],
+                     [Define to 1 if you have the 'termcap' library (-ltermcap)])
+                 AC_DEFINE(HAVE_LIBREADLINE, [0],
+                     [Define to 1 if you have the 'readline' library (-lreadline)])
+                 ],
+                 [enable_libless=false
+                 echo "Using libraries if available."
+                 # termcap is sometimes required by readline
+                 AC_CHECK_LIB([termcap], [tgetent], [], [])
+                 AC_CHECK_LIB([readline], [readline], [], [
+                     echo "libreadline could not be found, which is required to continue."
+                     echo "The libreadline-dev package may be required."
+                     exit 1
+                     ])
+                 ])
+
 AM_CONDITIONAL([ENABLE_GUI], [test x$enable_gui = xtrue])
+AM_CONDITIONAL([ENABLE_LIBLESS], [test x$enable_libless = xtrue])
 AC_OUTPUT

--- a/handlers.c
+++ b/handlers.c
@@ -43,8 +43,7 @@
 #include <limits.h>            /* to determine the word width */
 #include <errno.h>
 #include <inttypes.h>
-
-#include <readline/readline.h>
+#include <ctype.h>
 
 #include "commands.h"
 #include "endianness.h"

--- a/libreplacements.c
+++ b/libreplacements.c
@@ -1,0 +1,56 @@
+/*
+ libreplacements.c  Minimal function replacements for libraries.
+
+ Copyright (C) 2015 Jonathan Pelletier <funmungus(a)gmail.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include <stdio.h>
+
+#include "libreplacements.h"
+
+int rl_attempted_completion_over = 0;
+const char *rl_readline_name = "scanmem";
+rl_completion_func_t *rl_attempted_completion_function = NULL;
+
+/* always return NULL to show that there are no completions */
+char **rl_completion_matches(const char *text, rl_compentry_func_t
+                             *entry_function)
+{
+    return NULL;
+}
+
+/* show the prompt, then allocate, read and
+   return a line with getline() */
+char *readline(const char *prompt)
+{
+    char *line = NULL;
+    size_t n = 0;
+    ssize_t bytes_read;
+
+    printf("%s", prompt);
+    fflush(stdout);
+    bytes_read = getline(&line, &n, stdin);
+    if (bytes_read > 0)
+        line[bytes_read - 1] = '\0';  /* remove the trailing newline */
+
+    return line;
+}
+
+/* don't maintain a history */
+void add_history(const char *line)
+{
+}

--- a/libreplacements.h
+++ b/libreplacements.h
@@ -1,0 +1,36 @@
+/*
+ libreplacements.h  Minimal function replacements for libraries.
+
+ Copyright (C) 2015 Jonathan Pelletier <funmungus(a)gmail.com>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#ifndef _LIBREPLACEMENTS_INC
+#define _LIBREPLACEMENTS_INC
+
+typedef char *rl_compentry_func_t(const char *, int);
+typedef char **rl_completion_func_t(const char *, int, int);
+
+extern int rl_attempted_completion_over;
+extern const char *rl_readline_name;
+extern rl_completion_func_t *rl_attempted_completion_function;
+
+char **rl_completion_matches(const char *text, rl_compentry_func_t
+                             *entry_function);
+char *readline(const char *prompt);
+void add_history(const char *line);
+
+#endif

--- a/menu.c
+++ b/menu.c
@@ -32,8 +32,12 @@
 #include <string.h>
 #include <stdbool.h>
 
+#if defined(HAVE_LIBREADLINE) && HAVE_LIBREADLINE
 #include <readline/readline.h>
 #include <readline/history.h>
+#else
+#include "libreplacements.h"
+#endif
 
 #include "scanmem.h"
 #include "commands.h"


### PR DESCRIPTION
Enable bypassing library linking with --enable-libless option in configure script. This will allow building without libraries, but less features will be available.
libreplacements implements missing functions.

To build, ./configure --prefix=/usr --enable-libless && make
