### PR TITLE
Update handlers.c

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -339,8 +339,8 @@ bool handler__list(globals_t * vars, char **argv, unsigned argc)
         show_error("memory allocation failed.\n");
         return false;
     }
-    char *bytearray_suffix = ", [bytearray]";
-    char *string_suffix = ", [string]";
+    char *bytearray_suffix = ", [bytearray ]";
+    char *string_suffix = ", [string ]";
 
     USEPARAMS();
 


### PR DESCRIPTION
I noticed that this caused bytearray and string scans to freeze the GUI. The GUI is expecting a space after the type.