### PR TITLE
gui: add support for string/bytearray search with Python 3

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -676,20 +676,20 @@ class GameConqueror():
         return None
 
     # parse bytes dumped by scanmem into number, string, etc.
-    def bytes2value(self, typename, bytes):
-        if bytes is None:
+    def bytes2value(self, typename, databytes):
+        if databytes is None:
             return None
         if typename in TYPENAMES_G2STRUCT:
-            return struct.unpack(TYPENAMES_G2STRUCT[typename], bytes)[0]
+            return struct.unpack(TYPENAMES_G2STRUCT[typename], databytes)[0]
         elif typename == 'string':
-            bytes = str(bytes.decode())
-            return repr('%s'%(bytes,))[1:-1]
+            databytes = str(databytes.decode())
+            return repr('%s'%(databytes,))[1:-1]
         elif typename == 'bytearray':
-            bytes = bytes.decode()
-            return ' '.join(['%02x'%ord(i) for i in bytes])
+            databytes = databytes.decode()
+            return ' '.join(['%02x'%ord(i) for i in databytes])
         else:
-            return bytes
-    
+            return databytes
+
     def scan_for_addr(self, addr):
         bits = self.get_pointer_width()
         if bits is None:

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -907,7 +907,7 @@ class GameConqueror():
             # temporarily disable model for scanresult_liststore for the sake of performance
             self.scanresult_liststore.clear()
             for line in lines:
-                line = str(line)
+                line = str(line.decode())
                 line = line[line.find(']')+1:]
                 (a, o, rt, v, t) = list(map(str.strip, line.split(',')[:5]))
                 a = '%x'%(int(a,16),)

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -682,8 +682,10 @@ class GameConqueror():
         if typename in TYPENAMES_G2STRUCT:
             return struct.unpack(TYPENAMES_G2STRUCT[typename], bytes)[0]
         elif typename == 'string':
+            bytes = str(bytes.decode())
             return repr('%s'%(bytes,))[1:-1]
         elif typename == 'bytearray':
+            bytes = bytes.decode()
             return ' '.join(['%02x'%ord(i) for i in bytes])
         else:
             return bytes

--- a/gui/backend.py
+++ b/gui/backend.py
@@ -70,7 +70,7 @@ class GameConquerorBackend():
         return self.lib.get_num_matches()
 
     def get_version(self):
-        return self.lib.get_version().decode("utf-8")
+        return self.lib.get_version().decode()
 
     def get_scan_progress(self):
         return self.lib.get_scan_progress()


### PR DESCRIPTION
Python 3 intentionally doesn't convert from bytes to unicode. This is why the search for string/bytearray freezes in GameConqueror and causes a debug message. So explicitly convert strings returned by scanmem as bytes to unicode.

This has been tested with Python 2.7 and 3.4 and is suitable for 0.15 stable.

Reported-by: calculuswhiz