### PR TITLE
value/gui: rework error handling in and around valtostr()

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -916,6 +916,8 @@ class GameConqueror():
                 a = '%x'%(int(a,16),)
                 o = '%x'%(int(o[5:],16),)
                 t = t[1:-1]
+                if t == 'unknown':
+                    continue
                 self.scanresult_liststore.append([a, v, t, True, o, rt])
             self.scanresult_tv.set_model(self.scanresult_liststore)
 

--- a/handlers.c
+++ b/handlers.c
@@ -395,9 +395,7 @@ bool handler__list(globals_t * vars, char **argv, unsigned argc)
                 value_t val = data_to_val(reading_swath_index, reading_iterator /* ,MATCHES_AND_VALUES */);
                 truncval_to_flags(&val, flags);
 
-                if (valtostr(&val, v, buf_len) != true) {
-                    strncpy(v, "unknown", buf_len);
-                }
+                valtostr(&val, v, buf_len);
                 break;
             }
 
@@ -1169,9 +1167,7 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
     valcpy(&o, &old_val);
     valcpy(&n, &o);
 
-    if (valtostr(&o, buf, sizeof(buf)) == false) {
-        strncpy(buf, "unknown", sizeof(buf));
-    }
+    valtostr(&o, buf, sizeof(buf));
 
     if (INTERRUPTABLE()) {
         (void) detach(vars->target);
@@ -1205,9 +1201,7 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
             valcpy(&o, &n);
             truncval(&o, &old_val);
 
-            if (valtostr(&o, buf, sizeof(buf)) == false) {
-                strncpy(buf, "unknown", sizeof(buf));
-            }
+            valtostr(&o, buf, sizeof(buf));
 
             /* fetch new timestamp */
             t = time(NULL);

--- a/value.h
+++ b/value.h
@@ -99,7 +99,7 @@ typedef struct {
 
 /* used when output values to user */
 /* only work for numbers */
-bool valtostr(const value_t * val, char *str, size_t n); 
+void valtostr(const value_t *val, char *str, size_t n);
 bool parse_uservalue_bytearray(char **argv, unsigned argc, bytearray_element_t *array, uservalue_t * val); /* parse bytearray, the parameter array should be allocated beforehand */
 bool parse_uservalue_number(const char *nptr, uservalue_t * val); /* parse int or float */
 bool parse_uservalue_int(const char *nptr, uservalue_t * val);


### PR DESCRIPTION
When searching for numbers with the differential search (?, <, >, =),
the GUI freezes at the point when it should list the scan results
with Python 2 and 3. Analysis has shown that it happens if "unknown"
or a number as big as the buffer are printed without a type. The
printing to the buffer is completely unchecked. All this has been
touched by commit 1f34f3e7 ("implemented dataarray representation")
the last time back in 2010.

So check if the printing to the buffer results in valid output and
make sure that there is always a type printed. For the error case use
"unknown, [unknown]" to print a type as well. Move the error handling
completely into valtostr() and change the return type to void as it
is the same for all call locations.

If the type is unknown, then the GUI can't and shouldn't process such
results further. So ignore such lines coming from the scanmem 'list'
command.

This has been tested with Python 2.7 and 3.4, with values which were
too long before, with values which were reported as "unknown" without
a type, with the regular number, bytearray and string search again for
not introducing any regressions.

Reported-by: Geoff Maciolek
Fixes: GitHub issue #109