### PR TITLE
gui: fix the Hexview (esp. for Python 3)

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -39,6 +39,7 @@ from gi.repository import GObject
 from consts import *
 from hexview import HexView
 from backend import GameConquerorBackend
+from misc import u
 import misc
 
 import locale
@@ -741,7 +742,7 @@ class GameConqueror():
                 self.show_error(_('Cannot read memory'))
                 return
             self.last_hexedit_address = (start_addr, end_addr)
-            self.memoryeditor_hexview.payload=data
+            self.memoryeditor_hexview.payload = u(data)
             self.memoryeditor_hexview.base_addr = start_addr
         
         # set editable flag

--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -210,7 +210,7 @@ class AsciiText(BaseText):
         self.buffer.set_text('')
 
         bpl = self._parent.bpl
-        tot_lines = len(txt) / bpl
+        tot_lines = int(len(txt) / bpl)
 
         if len(txt) % bpl != 0:
             tot_lines += 1

--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -164,7 +164,7 @@ class AsciiText(BaseText):
             else:
                 iter = buffer.get_iter_at_mark(buffer.get_insert())
                 off = iter.get_offset()
-                org_off = off - off / (self._parent.bpl + 1)
+                org_off = off - int(off / (self._parent.bpl + 1))
                 self._parent.emit('char-changed', org_off, c)
                 self.select_a_char(buffer.get_iter_at_offset(off+1))
             return True
@@ -324,7 +324,7 @@ class HexText(BaseText):
                 iter = buffer.get_iter_at_mark(buffer.get_insert())
                 off = iter.get_offset()
                 pos = off % 3
-                org_off = off / 3
+                org_off = int(off / 3)
                 txt = buffer.get_text(
                         buffer.get_iter_at_offset(org_off*3),
                         buffer.get_iter_at_offset(org_off*3+2),

--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -122,40 +122,32 @@ class AsciiText(BaseText):
         )
         """
     def __on_move_cursor(self, textview, step_size, count, extend_selection, data=None):
-        if True: #step_size == Gtk.MovementStep.VISUAL_POSITIONS:
-            buffer = self.get_buffer()
-            insert_mark = buffer.get_insert()
-            insert_iter = buffer.get_iter_at_mark(insert_mark)
-            insert_off = insert_iter.get_offset()
-            if not extend_selection:
-                if (insert_off+1) % (self._parent.bpl+1) == 0:
-                    if count > 0:
-                        # try to move forward
-                        if insert_iter.is_end():
-                            end_iter = insert_iter.copy()
-                            insert_iter.backward_char()
-                        else:
-                            insert_iter.forward_char()
-                            end_iter = insert_iter.copy()
-                            end_iter.forward_char()
-                    elif count < 0:
-                        # try to move backward
-                        if insert_iter.is_start():
-                            end_iter = insert_iter.copy()
-                            end_iter.forward_char()
-                        else:
-                            end_iter = insert_iter.copy()
-                            insert_iter.backward_char()
+        buffer = self.get_buffer()
+        insert_mark = buffer.get_insert()
+        insert_iter = buffer.get_iter_at_mark(insert_mark)
+        insert_off = insert_iter.get_offset()
+        if not extend_selection:
+            if count > 0:
+                # try to move forward
+                if insert_iter.is_end() or \
+                   step_size != Gtk.MovementStep.VISUAL_POSITIONS:
+                    # at end or line down: stay
+                    insert_iter.backward_char()
                 else:
-                    if insert_iter.is_end():
-                        end_iter = insert_iter.copy()
+                    # move forward
+                    if (insert_off+1) % (self._parent.bpl+1) == 0:
+                        insert_iter.forward_char()
+            elif count < 0:
+                # try to move backward
+                if not insert_iter.is_start() and \
+                   step_size == Gtk.MovementStep.VISUAL_POSITIONS:
+                    # move backward (at start or line up: stay)
+                    if (insert_off+1) % (self._parent.bpl+1) == 1:
                         insert_iter.backward_char()
-                    else:
-                        end_iter = insert_iter.copy()
-                        end_iter.forward_char()
-                # select one char
-                buffer.select_range(insert_iter, end_iter)
-            
+                    insert_iter.backward_char()
+            # set end always to one char in front of start
+            end_iter = insert_iter.copy()
+            end_iter.forward_char()
             # select one char
             buffer.select_range(insert_iter, end_iter)
         return True

--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -585,33 +585,9 @@ class HexView(Gtk.Box):
 
 
     def __on_hex_change(self, buffer, iter, mark):
-        if not buffer.get_selection_bounds():
-            self.ascii_text.select_blocks() # Deselect
-            return True
-
-        start, end = buffer.get_selection_bounds()
-
-        s_off = start.get_offset()
-        e_off = end.get_offset()
-
-        self.ascii_text.select_blocks((s_off+1) / 3, (e_off-1) / 3+1)
         return True
 
     def __on_ascii_change(self, buffer, iter, mark):
-        if not self.ascii_text.buffer.get_selection_bounds():
-            self.hex_text.select_blocks() # Deselect
-            return True
-
-        start_iter, end_iter = self.ascii_text.buffer.get_selection_bounds()
-
-        start_off = start_iter.get_offset()
-        end_off = end_iter.get_offset()
-        bpl = self._bpl
-
-        self.hex_text.select_blocks(
-            start_off - start_off / (bpl + 1),
-            end_off - end_off / (bpl + 1)
-        )
         return True
 
     def do_char_changed(self, offset, charval):

--- a/gui/misc.py
+++ b/gui/misc.py
@@ -18,7 +18,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import sys
+import codecs
+
 from gi.repository import Gtk
+
+PY3K = sys.version_info >= (3, 0)
 
 # check syntax, data range etc.
 # translate if neccesary
@@ -154,3 +159,10 @@ def menu_append_item(menu, name, callback, data):
     item = Gtk.MenuItem(name)
     menu.append(item)
     item.connect('activate', callback, data)
+
+# for Python 3: convert to unicode just like Python 2 does
+def u(x):
+    if PY3K:
+        return codecs.unicode_escape_decode(x)[0]
+    else:
+        return x


### PR DESCRIPTION
With Python 2 the cursor movement is incorrect. The cursor can't be moved backwards and when moving a line down, then the cursor is also moved one position forward. This makes cursor control unusable. With Python 3 the hexview window even doesn't open at all and a Python debug message is printed instead as the payload data is in bytes and not in unicode. There is a recursion problem on ascii/hex change and conversions of division results to integer are missing.

All this is fixed by this pull request so that this behaves the same with Python 3 as with Python 2 and the hexview becomes actually usable.

The following issues are fixed: #103, #113 and #114.