### PR TITLE
v0.15.2 Python fixes: Python cache + unicode conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ config.status
 config.sub
 libtool
 ltmain.sh
+py-compile
 scanmem
 stamp-h1
 tags

--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,7 @@ AC_ARG_ENABLE(gui, [AS_HELP_STRING([--enable-gui],
                             [enable gameconqueror, the gui front-end of scanmem])])
 AM_CONDITIONAL([ENABLE_GUI], [test "x$enable_gui" = "xyes"])
 AS_IF([test "x$enable_gui" = "xyes"], [
+  AM_PATH_PYTHON([2.7])
   AC_CONFIG_FILES([
     gui/Makefile
     gui/icons/Makefile

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -683,10 +683,10 @@ class GameConqueror():
         if typename in TYPENAMES_G2STRUCT:
             return struct.unpack(TYPENAMES_G2STRUCT[typename], databytes)[0]
         elif typename == 'string':
-            databytes = str(databytes.decode())
+            databytes = str(u(databytes))
             return repr('%s'%(databytes,))[1:-1]
         elif typename == 'bytearray':
-            databytes = databytes.decode()
+            databytes = u(databytes)
             return ' '.join(['%02x'%ord(i) for i in databytes])
         else:
             return databytes
@@ -911,7 +911,7 @@ class GameConqueror():
             # temporarily disable model for scanresult_liststore for the sake of performance
             self.scanresult_liststore.clear()
             for line in lines:
-                line = str(line.decode())
+                line = str(u(line))
                 line = line[line.find(']')+1:]
                 (a, o, rt, v, t) = list(map(str.strip, line.split(',')[:5]))
                 a = '%x'%(int(a,16),)

--- a/gui/Makefile.am
+++ b/gui/Makefile.am
@@ -1,9 +1,10 @@
 SUBDIRS = icons
 
+gameconquerordir=$(datadir)/gameconqueror
+python_PYTHON = backend.py consts.py misc.py hexview.py GameConqueror.py
+pythondir = $(gameconquerordir)
 dist_bin_SCRIPTS = gameconqueror
 dist_gameconqueror_DATA = GameConqueror.xml GameConqueror_128x128.png GameConqueror_72x72.png
-dist_gameconqueror_DATA += backend.py consts.py misc.py hexview.py
-dist_gameconqueror_SCRIPTS = GameConqueror.py
 dist_desktop_in_files = GameConqueror.desktop.in
 dist_desktop_DATA = $(dist_desktop_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
@@ -17,7 +18,9 @@ dist_man_MANS = gameconqueror.1
 dist_doc_DATA = README TODO COPYING
 EXTRA_DIST = gameconqueror.in consts.py.in
 
-gameconquerordir=$(datadir)/gameconqueror
 desktopdir=$(datadir)/applications
 polkitdir=$(datadir)/polkit-1/actions
 appdatadir=$(datadir)/appdata
+
+install-data-hook:
+	chmod +x $(DESTDIR)$(gameconquerordir)/GameConqueror.py

--- a/gui/backend.py
+++ b/gui/backend.py
@@ -24,6 +24,7 @@ import ctypes
 import tempfile
 import re
 from gi.repository import GObject
+from misc import u
 
 class GameConquerorBackend():
     BACKEND_FUNCS = {
@@ -70,7 +71,7 @@ class GameConquerorBackend():
         return self.lib.get_num_matches()
 
     def get_version(self):
-        return self.lib.get_version().decode()
+        return u(self.lib.get_version())
 
     def get_scan_progress(self):
         return self.lib.get_scan_progress()


### PR DESCRIPTION
The Python handling for the GUI is non-standard. This is why the
Python cache isn't generated during the installation. It is
generated when calling gameconqueror instead and causes files to
stay after uninstalling GameConqueror. This is unclean. The
preferred GNU automake way is the following:
http://www.gnu.org/software/automake/manual/html_node/Python.html

Add AM_PATH_PYTHON() to detect the Python interpreter and switch
over to 'python_PYTHON' and 'pythondir' to let automake generate
the Python cache upon installation. But GameConqueror.py needs to
become executable again. Use the 'install-data-hook' and 'chmod'
for that.

Reported-by: @anthraxx
Fixes: GitHub issue #116

Converting strings to utf-8 with the .decode() method has the
problem that not all characters (like e.g. 0xfe) can be converted
to unicode. But with the u() function in misc.py which has been
introduced for the hexview we have a function which converts with
Python 3 to unicode just like Python 2 does. So use it everywhere
to convert to unicode.

This has been tested with Python 2.7 and 3.4.

Reported-by: @calculuswhiz
Fixes: GitHub issue #120 