### PR TITLE
maps: handle the gap behind .text of the exe

### DIFF
--- a/maps.c
+++ b/maps.c
@@ -4,6 +4,7 @@
  Copyright (C) 2006,2007,2009 Tavis Ormandy <taviso@sdf.lonestar.org>
  Copyright (C) 2009           Eli Dupree <elidupree@charter.net>
  Copyright (C) 2009,2010      WANG Lu <coolwanglu@gmail.com>
+ Copyright (C) 2014,2015      Sebastian Parschauer <s.parschauer@gmx.de>
 
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
@@ -48,9 +49,9 @@ bool readmaps(pid_t target, list_t * regions)
     char name[128], *line = NULL;
     char exelink[128];
     size_t len = 0;
-    unsigned int code_regions = 0;
+    unsigned int code_regions = 0, exe_regions = 0;
+    unsigned long prev_end = 0, load_addr = 0, exe_load = 0;
     bool is_exe = false;
-    unsigned long prev_end = 0, load_addr = 0;
 
 #define MAX_LINKBUF_SIZE 256
     char linkbuf[MAX_LINKBUF_SIZE], *exename = linkbuf;
@@ -104,46 +105,70 @@ bool readmaps(pid_t target, list_t * regions)
             if (sscanf(line, "%lx-%lx %c%c%c%c %x %x:%x %u %s", &start, &end, &read,
                     &write, &exec, &cow, &offset, &dev_major, &dev_minor, &inode, filename) >= 6) {
                 /*
-                 * get the load address for regions of the same ELF binary
+                 * get the load address for regions of the same ELF file
                  *
-                 * When a dynamic loader loads an executable or a library into
-                 * memory, there is one region per binary segment created:
+                 * When the ELF loader loads an executable or a library into
+                 * memory, there is one region per ELF segment created:
                  * .text (r-x), .rodata (r--), .data (rw-) and .bss (rw-). The
                  * 'x' permission of .text is used to detect the load address
-                 * (region start) and the end of the binary in memory. All
+                 * (region start) and the end of the ELF file in memory. All
                  * these regions have the same filename. The only exception
                  * is the .bss region. Its filename is empty and it is
                  * consecutive with the .data region. But the regions .bss and
-                 * .rodata may not be present with some binaries. This is why
+                 * .rodata may not be present with some ELF files. This is why
                  * we can't rely on other regions to be consecutive in memory.
                  * There should never be more than these four regions.
                  * The data regions use their variables relative to the load
                  * address. So determining it makes sense as we can get the
-                 * variable address used within the binariy with it.
+                 * variable address used within the ELF file with it.
+                 * But for the executable there is the special case that there
+                 * is a gap between .text and .rodata. Other regions might be
+                 * loaded via mmap() to it. So we have to count the number of
+                 * regions belonging to the exe separately to handle that.
                  * References:
                  * http://en.wikipedia.org/wiki/Executable_and_Linkable_Format
                  * http://wiki.osdev.org/ELF
                  * http://lwn.net/Articles/531148/
                  */
+
+                /* detect further regions of the same ELF file and its end */
                 if (code_regions > 0) {
                     if (exec == 'x' || (strncmp(filename, binname,
                       MAX_LINKBUF_SIZE) != 0 && (filename[0] != '\0' ||
                       start != prev_end)) || code_regions >= 4) {
                         code_regions = 0;
                         is_exe = false;
+                        /* exe with .text and without .data is impossible */
+                        if (exe_regions > 1)
+                            exe_regions = 0;
                     } else {
                         code_regions++;
+                        if (is_exe)
+                            exe_regions++;
                     }
                 }
                 if (code_regions == 0) {
+                    /* detect the first region belonging to an ELF file */
                     if (exec == 'x' && filename[0] != '\0') {
                         code_regions++;
-                        if (strncmp(filename, exename, MAX_LINKBUF_SIZE) == 0)
+                        if (strncmp(filename, exename, MAX_LINKBUF_SIZE) == 0) {
+                            exe_regions = 1;
+                            exe_load = start;
                             is_exe = true;
+                        }
+                        strncpy(binname, filename, MAX_LINKBUF_SIZE);
+                        binname[MAX_LINKBUF_SIZE - 1] = '\0';  /* just to be sure */
+                    /* detect the second region of the exe after skipping regions */
+                    } else if (exe_regions == 1 && filename[0] != '\0' &&
+                      strncmp(filename, exename, MAX_LINKBUF_SIZE) == 0) {
+                        code_regions = ++exe_regions;
+                        load_addr = exe_load;
+                        is_exe = true;
                         strncpy(binname, filename, MAX_LINKBUF_SIZE);
                         binname[MAX_LINKBUF_SIZE - 1] = '\0';  /* just to be sure */
                     }
-                    load_addr = start;
+                    if (exe_regions < 2)
+                        load_addr = start;
                 }
                 prev_end = end;
 


### PR DESCRIPTION
With the 04/2015 Linux kernel commit a87938b2e246
("fs/binfmt_elf.c: fix bug in loading of PIE binaries")
we've noticed that our assumption that nothing gets loaded into
the gap behind the .text region of the executable has proven wrong.
Unrelated regions might be loaded via mmap() to that location.
Scanmem sets the region type to 'misc' instead of 'exe' for the
.rodata, .data and .bss sections of the executable and also the
load address is incorrect this way.

So count the regions belonging to the executable separately and if
there are not at least two of them, don't reset that count and try
to detect further regions belonging to the executable. There must
be at least a .data region. Also remember the load address of the
executable and assign it to the other regions belonging to it.

This has been tested with PIE binaries with and without an affected
kernel. This has been also tested with regular executables without
PIE with and without an affected kernel.

Reference:
https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=a87938b2e246b81b4fb713edb371a9fa3c5c3c86

Fixes: GitHub issue #122