### PR TITLE
Fix XDG_RUNTIME_DIR issues for Ubuntu

### DIFF
--- a/gui/gameconqueror.in
+++ b/gui/gameconqueror.in
@@ -3,7 +3,7 @@
 DATADIR=@PKGDATADIR@
 
 if [ -e "/usr/bin/pkexec" ]; then
-    exec /usr/bin/pkexec $DATADIR/GameConqueror.py
+    exec /usr/bin/pkexec env DISPLAY=$DISPLAY XAUTHORITY=$XAUTHORITY $DATADIR/GameConqueror.py
 else
     echo "install policykit!"
 fi


### PR DESCRIPTION
In Ubuntu 14.04 with mate (possibly others),
not exporting DISPLAY and XAUTHORITY causes gameconqueror to fail to
load with errors like:
   error: XDG_RUNTIME_DIR not set in the environment
    (GameConqueror.py:4181): Gtk-CRITICAL **: gtk_clipboard_get_for_display:
        assertion 'display != NULL' failed

This change allows gameconqueror to work again in Ubuntu 14.04