### PR TITLE
add ability to reset matches but keep regions

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -482,7 +482,19 @@ bool handler__reset(globals_t * vars, char **argv, unsigned argc)
 {
     USEPARAMS();
 
+    bool keep_regions = false;
+
+    for ( unsigned idx = 0; idx < argc; ++idx ) {
+        if ( strcmp(argv[idx], "keep-regions")==0)
+            keep_regions = true;
+    }
+
     if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
+
+    if (keep_regions) {
+        show_info("matches reseted, but regions were kept\n");
+        return true;
+    }
 
     /* refresh list of regions */
     l_destroy(vars->regions);

--- a/handlers.c
+++ b/handlers.c
@@ -484,7 +484,11 @@ bool handler__reset(globals_t * vars, char **argv, unsigned argc)
 
     bool keep_regions = false;
 
-    for ( unsigned idx = 0; idx < argc; ++idx ) {
+    if (argc == 1 && strcmp(argv[0], "mreset")==0)
+        keep_regions = true;
+
+    unsigned idx = 0;
+    for (; idx < argc; ++idx ) {
         if ( strcmp(argv[idx], "keep-regions")==0)
             keep_regions = true;
     }
@@ -909,6 +913,10 @@ bool handler__default(globals_t * vars, char **argv, unsigned argc)
     bytearray_element_t *array = NULL;
 
     USEPARAMS();
+
+    if (argc == 1 && strcmp(argv[0], "mreset")==0) {
+        return handler__reset(vars, argv, argc);
+    }
 
     switch(vars->options.scan_data_type)
     {

--- a/handlers.h
+++ b/handlers.h
@@ -68,10 +68,10 @@ bool handler__list(globals_t * vars, char **argv, unsigned argc);
 bool handler__delete(globals_t * vars, char **argv, unsigned argc);
 
 #define RESET_SHRTDOC "forget all matches, and reinitialise regions"
-#define RESET_LONGDOC "usage: reset\n" \
+#define RESET_LONGDOC "usage: reset [keep-regions]\n" \
                 "Forget all matches and regions, and reread regions from the relevant\n" \
                 "maps file. Useful if you have made an error, or want to find a new\n" \
-                "variable.\n"
+                "variable. Supply <keep-regions> option to keep current region list.\n"
 
 bool handler__reset(globals_t * vars, char **argv, unsigned argc);
 


### PR DESCRIPTION
after [reset] command i need always remove regions by [dregion] command again and again.
this patch adds option to [reset] command to keep current region list
