### PR TITLE
Add Android standalone toolchain build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ po/POTFILES
 po/ja.gmo
 po/ru.gmo
 po/stamp-it
+# Android builds
+# libreadline and ncurses downloads and links
+readline-*
+ncurses-*
+readline
+ncurses

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,11 @@ libscanmem_la_SOURCES = commands.h \
     value.h \
     value.c 
 
+if !HAVE_GETLINE
+  libscanmem_la_SOURCES += getline.h \
+      getline.c
+endif
+
 if !WITH_READLINE
   libscanmem_la_SOURCES += readline.h \
       readline.c

--- a/README
+++ b/README
@@ -45,6 +45,13 @@ GameConqueror is a GUI front-end for scanmem, providing more features, such as:
 
 See gui/README for more detail.
 
+## Android
+You need a [standalone toolchain of Android NDK]
+(https://developer.android.com/ndk/guides/standalone_toolchain.html#itc) (Advanced method)
+to build interactive capabilities for Android.
+For more information, run:
+
+  ./build_for_android.sh help
 
 ## License: 
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,2 +1,8 @@
 #!/bin/sh
-libtoolize -c && aclocal -I m4 && automake -c --add-missing && autoconf && intltoolize -f -c
+
+LIBTOOLIZE=libtoolize
+if [ "$(uname -s)" = "Darwin" ]; then
+    LIBTOOLIZE=glibtoolize  # install via brew
+fi
+
+$LIBTOOLIZE -c && aclocal -I m4 && automake -c --add-missing && autoconf && intltoolize -f -c

--- a/build_for_android.sh
+++ b/build_for_android.sh
@@ -1,0 +1,154 @@
+#!/bin/sh
+
+if [ "x$1" = "x--help" ] || [ "x$1" = "xhelp" ] || [ "x$1" = "x-h" ]; then
+    echo "
+  ## Before building:
+      # Run autogen.sh if \"./configure\" does not exist.
+      # From scanmem source directory
+      ./autogen.sh
+
+  ## For libreadline support:
+      # HOST is the compiler architecture for your toolchain and Android
+      # device. (e.g. arm-linux-androideabi)
+      # NDK_STANDALONE_TOOLCHAIN is the directory of your NDK standalone
+      # toolchain.
+
+      # Install libreadline to your NDK sysroot.
+      # From libreadline source directory, execute:
+      export PATH=\"\$NDK_STANDALONE_TOOLCHAIN/bin:\$PATH\"
+      bash_cv_wcwidth_broken=false ./configure --host=\"\$HOST\" \\
+          --disable-shared --enable-static \\
+          --prefix=\"\$NDK_STANDALONE_TOOLCHAIN/sysroot/usr\"
+      make
+      make install
+
+      # Install ncurses to your NDK sysgen.
+      # From ncurses source directory, execute:
+      export PATH=\"\$NDK_STANDALONE_TOOLCHAIN/bin:\$PATH\"
+      ac_cv_header_locale_h=no ./configure --host=\"\$HOST\" \\
+          --disable-shared --enable-static \\
+          --prefix=\"\$NDK_STANDALONE_TOOLCHAIN/sysroot/usr\"
+      make
+      make install
+
+  ## Building for Android 5.0 and above requires exporting PIE flags, such as:
+      export CFLAGS="-fPIE" LDFLAGS="-pie"
+
+  ## To build with standalone toolchain:
+      export NDK_STANDALONE_TOOLCHAIN=\"/your/toolchain/path\"
+      export HOST=\"your-androideabi\" # Default arm-linux-androideabi
+      ./build_for_android.sh
+
+  ## Advanced features and Environment variables that may be set...
+  NDK_STANDALONE_TOOLCHAIN - A standalone toolchain is required to build full
+      capabilities.
+  HOST                     - Compiler architecture that will be used for
+      cross-compiling, default is arm-linux-androideabi
+  SCANMEM_HOME             - Path which has scanmem sources, and will be used
+      to build scanmem.  Default current directory
+  LIBREADLINE_DIR          - Path which has libreadline sources to build
+      automatically.  Default is to download sources
+  NCURSES_DIR              - Path which has ncurses sources to build
+      automatically.  Default is to download sources
+"
+  exit 0
+fi
+
+# Resolve ndk toolchain or other
+if [ "x${NDK_STANDALONE_TOOLCHAIN}" = "x" ]; then
+  echo "NDK_STANDALONE_TOOLCHAIN was not found.
+Please enter the toolchain path:"
+  read NDK_STANDALONE_TOOLCHAIN
+  # Nothing entered
+  if [ "x${NDK_STANDALONE_TOOLCHAIN}" = "x" ]; then
+    echo "Error: Please set \$NDK_STANDALONE_TOOLCHAIN env variable." 1>&2
+    exit 1
+  fi
+fi
+export SYSROOT="${NDK_STANDALONE_TOOLCHAIN}/sysroot"
+export PATH="${NDK_STANDALONE_TOOLCHAIN}/bin:${PATH}"
+
+# Host architecture
+if [ "x${HOST}" = "x" ]; then
+  HOST=arm-linux-androideabi
+  echo "Env variable \$HOST, host architecture, is not specified.
+Defaulting to ${HOST}"
+fi
+
+# Build and return directory
+if [ "x${SCANMEM_HOME}" = "x" ]; then
+  export SCANMEM_HOME="$(pwd)"
+else
+  cd "${SCANMEM_HOME}"
+fi
+
+# Processor count for make instructions
+procnum="$(getconf _NPROCESSORS_ONLN)"
+if [ "x${procnum}" = "x" ] || [ $procnum -eq 0 ]; then
+  procnum=1
+fi
+
+# Do not fail for source downloads, workarounds may be found for broken links
+if [ ! -f "${SYSROOT}/usr/lib/libreadline.a" ]; then
+  # Build libreadline for android
+  if [ "x${LIBREADLINE_DIR}" = "x" ]; then
+    echo "LIBREADLINE_DIR was not found.  Please enter the path where
+libreadline source is located, or press enter to try a source download:"
+    read LIBREADLINE_DIR
+    if [ "x${LIBREADLINE_DIR}" = "x" ]; then
+      echo "Downloading libreadline..."
+      if [ ! -f readline-6.3.tar.gz ]; then
+        wget -c ftp://ftp.gnu.org/gnu/readline/readline-6.3.tar.gz
+      fi
+      tar xvf readline-6.3.tar.gz
+      export LIBREADLINE_DIR="$(pwd)/readline-6.3"
+    fi
+  fi
+  cd "${LIBREADLINE_DIR}"
+  bash_cv_wcwidth_broken=false ./configure --host="${HOST}" \
+      --disable-shared --enable-static --prefix="${SYSROOT}/usr"
+  make -j ${procnum}
+  make install
+  cd "${SCANMEM_HOME}"
+  # To make sure headers can be found
+  if [ ! -f readline ]; then
+    ln -s "${LIBREADLINE_DIR}" readline
+  fi
+fi
+
+# ncurses, same logic as libreadline
+if [ ! -f "${SYSROOT}/usr/lib/libncurses.a" ]; then
+  # Build libncurses for android (needed by libreadline)
+  if [ "x${NCURSES_DIR}" = "x" ]; then
+    echo "NCURSES_DIR was not found.  Please enter the path where
+ncurses source is located, or press enter to try a source download:"
+    read NCURSES_DIR
+    if [ "x${NCURSES_DIR}" = "x" ]; then
+      echo "Downloading ncurses..."
+      if [ ! -f ncurses-6.0.tar.gz ]; then
+        wget -c http://invisible-mirror.net/archives/ncurses/ncurses-6.0.tar.gz
+      fi
+      tar xvf ncurses-6.0.tar.gz
+      export NCURSES_DIR="$(pwd)/ncurses-6.0"
+    fi
+  fi
+  cd "${NCURSES_DIR}"
+  ac_cv_header_locale_h=no ./configure --host="${HOST}" \
+      --disable-shared --enable-static --prefix="${SYSROOT}/usr"
+  make -j ${procnum}
+  make install
+  cd "${SCANMEM_HOME}"
+  # To make sure headers can be found
+  if [ ! -f ncurses ]; then
+    ln -s "${NCURSES_DIR}" ncurses
+  fi
+fi
+
+# Build scanmem for android
+if [ "$(uname -s)" = "Darwin" ]; then
+  PATH=/usr/local/opt/gettext/bin:${PATH} # brew install gettext
+fi
+LIBS="-lncurses -lm" ./configure --host="${HOST}" --prefix="${SYSROOT}/usr" \
+    --enable-static --disable-shared
+[ "$?" != "0" ] && exit 1
+make -j ${procnum} && make install

--- a/config.h.in
+++ b/config.h.in
@@ -27,6 +27,12 @@
 /* Define to 1 if you have the <fcntl.h> header file. */
 #undef HAVE_FCNTL_H
 
+/* Define to 1 if you have the `fgetln' function. */
+#undef HAVE_FGETLN
+
+/* Define to 1 if you have the `getline' function. */
+#undef HAVE_GETLINE
+
 /* Define to 1 if you have the <inttypes.h> header file. */
 #undef HAVE_INTTYPES_H
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,21 @@ AC_TYPE_SSIZE_T
 
 AC_C_BIGENDIAN
 
+# Detect the host OS
+android="no"
+AC_CANONICAL_HOST
+case "$host_os" in
+  *android*)
+    android="yes"
+    AC_MSG_NOTICE([Android detected])
+    ;;
+  linux*)
+    AC_MSG_NOTICE([Linux detected])
+    ;;
+  *)
+    AC_MSG_NOTICE([Your platform is not currently supported])
+    ;;
+esac
 
 # also need to check if the file is zero'ed (some hardened systems)
 AC_CHECK_FILE([/proc/self/maps], [], [

--- a/configure.ac
+++ b/configure.ac
@@ -25,8 +25,6 @@ AM_CONDITIONAL([HAVE_GETLINE], [test "x$ac_cv_func_getline" != "xno"])
 AC_CHECK_HEADERS(fcntl.h limits.h stddef.h sys/time.h)
 
 AC_FUNC_ALLOCA
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
 AC_FUNC_STRTOD
 
 AC_TYPE_INT8_T
@@ -60,22 +58,32 @@ case "$host_os" in
     ;;
 esac
 
-# also need to check if the file is zero'ed (some hardened systems)
-AC_CHECK_FILE([/proc/self/maps], [], [
+AS_IF([test "x$android" = "xno"], [
+  # also need to check if the file is zero'ed (some hardened systems)
+  AC_CHECK_FILE([/proc/self/maps], [], [
     echo "This system does not seem to have /proc/pid/maps files."
     exit 1
-])
+  ])
 
-# also need to check this file works
-AC_CHECK_FILE([/proc/self/mem], [
+  # also need to check this file works
+  AC_CHECK_FILE([/proc/self/mem], [
     # LARGEFILE support required for this to work
     AC_SYS_LARGEFILE
     AC_DEFINE(HAVE_PROCMEM, [1], [Enable /proc/pid/mem support])
-],[
+  ],[
     # This will hurt performance.
     echo "This system does not seem to have /proc/pid/mem files."
     echo "Falling back to ptrace() only support."
     AC_DEFINE(HAVE_PROCMEM, [0], [Enable /proc/pid/mem support])
+  ])
+  # malloc optimizations without Android
+  AC_FUNC_MALLOC
+  AC_FUNC_REALLOC
+], [
+  # supported on Android
+  AC_SYS_LARGEFILE
+  # /proc/pid/mem is there but reading interesting data fails
+  AC_DEFINE(HAVE_PROCMEM, [0], [Enable /proc/pid/mem support])
 ])
 
 # copied from ubuntu-tweak

--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,17 @@ LT_INIT
 
 IT_PROG_INTLTOOL
 
-AC_CHECK_FUNCS(memset strcasecmp strchr strdup strerror strtoul)
+AC_CHECK_FUNCS(memset strcasecmp strchr strdup strerror strtoul getline)
+
+if test "x$ac_cv_func_getline" = "xno"; then
+  AC_CHECK_FUNCS(fgetln)
+  if test "x$ac_cv_func_fgetln" = "xno"; then
+    AC_MSG_ERROR([Cannot build without working getline().])
+  else
+    AC_MSG_NOTICE([Using the fgetln()-based getline() replacement.])
+  fi
+fi
+AM_CONDITIONAL([HAVE_GETLINE], [test "x$ac_cv_func_getline" != "xno"])
 
 AC_CHECK_HEADERS(fcntl.h limits.h stddef.h sys/time.h)
 

--- a/getline.c
+++ b/getline.c
@@ -1,0 +1,85 @@
+/*
+    Replace getline() with BSD specific fgetln().
+
+    Copyright (C) 2015 JianXiong Zhou <zhoujianxiong2@gmail.com>
+    Copyright (C) 2015 Jonathan Pelletier <funmungus(a)gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "getline.h"
+
+#if !defined(HAVE_GETLINE) && defined(HAVE_FGETLN)
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+
+/*
+ * Avoid frequent malloc()/free() calls
+ * (determined by getline() test on Linux)
+ */
+#define BUF_MIN 120
+
+ssize_t getline(char **lineptr, size_t *n, FILE *stream)
+{
+    char *lptr;
+    size_t len = 0;
+
+    /* Check for invalid arguments */
+    if (lineptr == NULL || n == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    lptr = fgetln(stream, &len);
+    if (lptr == NULL) {
+        /* Invalid stream */
+        errno = EINVAL;
+        return -1;
+    }
+
+    /*
+     * getline() returns a null byte ('\0') terminated C string
+     * but fgetln() returns characters without '\0' termination
+     */
+    if (*lineptr == NULL) {
+        *n = BUF_MIN;
+        goto alloc_buf;
+    }
+
+    /* Realloc the original pointer */
+    if (*n < len + 1) {
+        free(*lineptr);
+
+        *n = len + 1;
+alloc_buf:
+        *lineptr = malloc(*n);
+        if (*lineptr == NULL) {
+            *n = 0;
+            return -1;
+        }
+    }
+
+    /* Copy over the string */
+    memcpy(*lineptr, lptr, len);
+    (*lineptr)[len] = '\0';
+
+    /*
+     * getline() and fgetln() both return len including the
+     * delimiter but without the null byte at the end
+     */
+    return len;
+}
+
+#endif

--- a/getline.h
+++ b/getline.h
@@ -1,0 +1,32 @@
+/*
+    Replace getline() with BSD specific fgetln().
+
+    Copyright (C) 2015 JianXiong Zhou <zhoujianxiong2@gmail.com>
+    Copyright (C) 2015 Jonathan Pelletier <funmungus(a)gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef GETLINE_H
+#define GETLINE_H
+
+#include "config.h"
+
+#ifndef HAVE_GETLINE
+#include <stdio.h>
+
+ssize_t getline(char **lineptr, size_t *n, FILE *stream);
+#endif
+
+#endif /* GETLINE_H */

--- a/maps.c
+++ b/maps.c
@@ -37,6 +37,7 @@
 
 #include "list.h"
 #include "maps.h"
+#include "getline.h"
 #include "scanmem.h"
 #include "show_message.h"
 

--- a/menu.c
+++ b/menu.c
@@ -38,6 +38,7 @@
 #include "readline.h"
 #endif
 
+#include "getline.h"
 #include "scanmem.h"
 #include "commands.h"
 #include "show_message.h"

--- a/readline.c
+++ b/readline.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 
 #include "readline.h"
+#include "getline.h"
 
 int rl_attempted_completion_over = 0;
 const char *rl_readline_name = "scanmem";


### PR DESCRIPTION
This is the rework of PR #139.

Changes:
* major rework of the getline() replacement
* wrote an own commit to check for getline() and fgetln() failing configure if both are missing
* reworked or even wrote the commit descriptions
* reduced the number of checks for HAVE_GETLINE by moving the check to getline.h
* reworked the host OS detection with an own commit using the standard method
* fixed a typo in configure.ac changes
* removed the ndk-build method completely as it is not ready for the mainline yet
* removed setting of the "-pie" and "-fPIE" flags (can be done by exporting CFLAGS and LDFLAGS)

@funmungus, please review and test. This is what I would want to merge.
You've put too much stuff into your PR and haven't documented your commits correctly. This causes big delays as maintainers either have to reverse engineer your changes or tend to reject the PR. The ndk-build method is plain not mainline-ready. So it doesn't make much sense to send it within the same PR. The getline() replacement hasn't been tested against GNU getline(). As the first commit in such a bad shape I was really tending to reject the whole PR. I would say that neither of you deserves a copyright for this. I've found the same mistakes [here](https://android.googlesource.com/platform/external/elfutils/+/b6f4a7a/bionic-fixup/getline.c). Nevertheless, there is quite some demand for Android support for scanmem. This is why I've invested the time to get this right. Thanks for your work!