### PR TITLE
Correct !=/= (changed/unchanged) help text.

### DIFF
--- a/handlers.h
+++ b/handlers.h
@@ -114,8 +114,8 @@ bool handler__lregions(globals_t * vars, char **argv, unsigned argc);
 
 #define GREATERTHAN_SHRTDOC "match values that have increased or greater than some number"
 #define LESSTHAN_SHRTDOC "match values that have decreased or less than some number"
-#define NOTCHANGED_SHRTDOC "match all variables that have changed since last scan"
-#define CHANGED_SHRTDOC "match all variables that have not changed since last scan"
+#define NOTCHANGED_SHRTDOC "match all variables that have not changed since last scan"
+#define CHANGED_SHRTDOC "match all variables that have changed since last scan"
 #define INCREASED_SHRTDOC "match values that have increased by some given number"
 #define DECREASED_SHRTDOC "match values that have decreased by some given number"
 


### PR DESCRIPTION
Just started playing with scanmem (very cool), and noticed that the help text for the = and != functions was backward from their actual function.  This change just makes the text match the function and #define macro names.