### PR TITLE
Squash another Gtk warning

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -663,7 +663,7 @@ class GameConqueror():
     ############################
     # core functions
     def show_error(self, msg):
-        dialog = Gtk.MessageDialog(None
+        dialog = Gtk.MessageDialog(self.main_window
                                  ,Gtk.DialogFlags.MODAL
                                  ,Gtk.MessageType.ERROR
                                  ,Gtk.ButtonsType.OK

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -725,7 +725,7 @@ class GameConqueror():
         try:
             self.read_maps()
         except:
-            self.show_error(_('Cannot retieve memory maps of that process, maybe it has exited (crashed), or you don\'t have enough privilege'))
+            self.show_error(_('Cannot retrieve memory maps of that process, maybe it has exited (crashed), or you don\'t have enough privilege'))
             return
         selected_region = None
         if addr:
@@ -807,7 +807,7 @@ class GameConqueror():
             self.pid = 0
             self.process_label.set_text(_('No process selected'))
             self.process_label.set_property('tooltip-text', _('Select a process'))
-            self.show_error(_('Cannot retieve memory maps of that process, maybe it has exited (crashed), or you don\'t have enough privilege'))
+            self.show_error(_('Cannot retrieve memory maps of that process, maybe it has exited (crashed), or you don\'t have enough privilege'))
         self.process_label.set_text('%d - %s' % (pid, process_name))
         self.process_label.set_property('tooltip-text', process_name)
 

--- a/gui/GameConqueror.xml
+++ b/gui/GameConqueror.xml
@@ -715,6 +715,7 @@ Public License instead of this License.  But first, please read
   </object>
   <object class="GtkDialog" id="AddCheatDialog">
     <property name="can_focus">False</property>
+    <property name="transient_for">MainWindow</property>
     <property name="border_width">5</property>
     <property name="title" translatable="yes">Manually add an entry</property>
     <property name="resizable">False</property>
@@ -1393,6 +1394,7 @@ Public License instead of this License.  But first, please read
     <property name="width_request">350</property>
     <property name="height_request">500</property>
     <property name="can_focus">False</property>
+    <property name="transient_for">MainWindow</property>
     <property name="title" translatable="yes">Press Ctrl+F to search for a process</property>
     <property name="modal">True</property>
     <property name="icon">GameConqueror_128x128.png</property>


### PR DESCRIPTION
Fix the `Gtk-Message: GtkDialog mapped without a transient parent. This is discouraged.` by setting the transient parent.

Notice that this changes the default spawn point for the subwindows, not sure if it's desired.

I also sneaked in a typo fix.

-------------

It's not extremely clear to me how you manage the repo's history, I'd have expected you to merge master into stable to make the new release, but you seem to have 2 separate branches.
Tell me if you want it rebased on top of somewhere else (as I already said a while ago, a `CONTRIBUTING.md` wouldn't hurt).