### PR TITLE
ptrace: remove superfluous min() macro

### DIFF
--- a/ptrace.c
+++ b/ptrace.c
@@ -63,8 +63,6 @@
 #include "scanmem.h"
 #include "show_message.h"
 
-#define min(a,b) (((a)<(b))?(a):(b))
-
 /* Progress handling */
 #define NUM_DOTS (10)
 #define NUM_SAMPLES (100)


### PR DESCRIPTION
The MIN() macro is defined in scanmem.h. Also, this macro
definition used lowercase rather than the standard convention to
put function-like macros in all caps to remind the programmer that
they aren't invoking a function.

Vim automatically stripped some trailing whitespace.