### PR TITLE
gui: add basic cmd line parameter parsing

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -133,6 +133,7 @@ class GameConqueror():
         
         self.scanoption_frame = self.builder.get_object('ScanOption_Frame')
         self.scanprogress_progressbar = self.builder.get_object('ScanProgress_ProgressBar')
+        self.input_box = self.builder.get_object('Value_Input')
 
         self.scan_button = self.builder.get_object('Scan_Button')
         self.reset_button = self.builder.get_object('Reset_Button')
@@ -1053,6 +1054,7 @@ if __name__ == '__main__':
                                      epilog='Report bugs to <%s>.' %(PACKAGE_BUGREPORT,)
                                     )
     parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + VERSION)
+    parser.add_argument('-s', '--search', metavar='val', dest='search_value', help='prefill the search box')
     parser.add_argument("pid", nargs='?', type=int, help="PID of the process")
     args = parser.parse_args()
 
@@ -1060,6 +1062,10 @@ if __name__ == '__main__':
     if (args.pid is not None) :
         process_name = os.popen('ps -p ' + str(args.pid) + ' -o command=').read().strip()
         gc_instance.select_process(args.pid, process_name)
-    
+
+    # Prefill the search box (if asked)
+    if (args.search_value is not None) :
+        gc_instance.input_box.set_text(args.search_value)
+
     # Start
     gc_instance.main()

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -810,8 +810,9 @@ class GameConqueror():
             self.process_label.set_property('tooltip-text', _('Select a process'))
             self.show_error(_('Cannot retrieve memory maps of that process, maybe it has '
                               'exited (crashed), or you don\'t have enough privileges'))
-        self.process_label.set_text('%d - %s' % (pid, process_name))
-        self.process_label.set_property('tooltip-text', process_name)
+        else:
+            self.process_label.set_text('%d - %s' % (pid, process_name))
+            self.process_label.set_property('tooltip-text', process_name)
 
         self.command_lock.acquire()
         self.backend.send_command('pid %d' % (pid,))

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -23,7 +23,7 @@
 
 import sys
 import os
-import re
+import argparse
 import struct
 import tempfile
 import platform
@@ -1041,9 +1041,25 @@ class GameConqueror():
         if self.backend.get_version() != VERSION:
             self.show_error(_('Version of scanmem mismatched, you may encounter problems. Please make sure you are using the same version of GameConqueror as scanmem.'))
 
-    
 
 if __name__ == '__main__':
     GObject.threads_init()
     Gdk.threads_init()
-    GameConqueror().main()
+    gc_instance = GameConqueror()
+    
+    # Parse cmdline arguments
+    parser = argparse.ArgumentParser(prog='GameConqueror',
+                                     description="A GUI for scanmem, a game hacking tool"
+
+                                    )
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + VERSION)
+    parser.add_argument("pid", nargs='?', type=int, help="PID of the process")
+    args = parser.parse_args()
+
+    # Attach to given pid (if any)
+    if (args.pid is not None) :
+        process_name = os.popen('ps -p ' + str(args.pid) + ' -o command=').read()
+        gc_instance.select_process(args.pid, process_name)
+    
+    # Start
+    gc_instance.main()

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -1049,8 +1049,8 @@ if __name__ == '__main__':
     
     # Parse cmdline arguments
     parser = argparse.ArgumentParser(prog='GameConqueror',
-                                     description="A GUI for scanmem, a game hacking tool"
-
+                                     description="A GUI for scanmem, a game hacking tool",
+                                     epilog='Report bugs to <%s>.' %(PACKAGE_BUGREPORT,)
                                     )
     parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + VERSION)
     parser.add_argument("pid", nargs='?', type=int, help="PID of the process")

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -1058,7 +1058,7 @@ if __name__ == '__main__':
 
     # Attach to given pid (if any)
     if (args.pid is not None) :
-        process_name = os.popen('ps -p ' + str(args.pid) + ' -o command=').read()
+        process_name = os.popen('ps -p ' + str(args.pid) + ' -o command=').read().strip()
         gc_instance.select_process(args.pid, process_name)
     
     # Start

--- a/gui/GameConqueror.xml
+++ b/gui/GameConqueror.xml
@@ -1002,7 +1002,7 @@ Public License instead of this License.  But first, please read
  For number types: 
 &lt;span font_family="monospace"&gt;
  &lt;b&gt;N&lt;/b&gt;         Exactly this number
- &lt;b&gt;N..N&lt;/b&gt;      Range between two numbers
+ &lt;b&gt;N..M&lt;/b&gt;      Range between two numbers
  &lt;b&gt;?&lt;/b&gt;         Unknown initial value
  &lt;b&gt;&amp;gt; or +&lt;/b&gt;    Increased values
  &lt;b&gt;&amp;lt; or -&lt;/b&gt;    Decreased values
@@ -1012,7 +1012,7 @@ Public License instead of this License.  But first, please read
  &lt;b&gt;&amp;lt; N&lt;/b&gt;       Less than N
  &lt;b&gt;+ N&lt;/b&gt;       Increased by N
  &lt;b&gt;- N&lt;/b&gt;       Decreased by N
- &lt;b&gt;!= N&lt;/b&gt;       Other than N
+ &lt;b&gt;!= N&lt;/b&gt;      Other than N
 &lt;/span&gt;
  where N could be a number of a simple math expression embraced by (), e.g.
  12
@@ -1166,7 +1166,7 @@ Public License instead of this License.  But first, please read
                                 <property name="height_request">28</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Specify how float numbers should be rounded. Not avaiable in this version</property>
+                                <property name="tooltip_text" translatable="yes">Specify how float numbers should be rounded. Not available in this version</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Round Type:</property>
                               </object>

--- a/gui/consts.py.in
+++ b/gui/consts.py.in
@@ -5,6 +5,7 @@ VERSION = '@VERSION@'
 DATA_DIR = '@PKGDATADIR@'
 LOCALEDIR = '@LOCALEDIR@'
 GETTEXT_PACKAGE = '@GETTEXT_PACKAGE@'
+PACKAGE_BUGREPORT = '@PACKAGE_BUGREPORT@'
 
 SETTINGS = {'scan_data_type':'int32'
            ,'lock_data_type':'int32'


### PR DESCRIPTION
**Not production ready, opened a PR for feedback**

I added basic cmdline parsing to GC, modelling both the scanmem parameters and help format.
The average user sure won't care, but I like to be able to start it with

    gameconqueror `pidof thingy`

(cmdline passthrough of 481222179e2f032d1195397e462f19b109ab7ee2 gets the parameters to the actual `.py`).

`scanmem` has an extra `--pid` option, but I find it redundant and confusing, as

    scanmem --pid 1 -- 2

will open `2`, completely forgetting about `1`.

The implementation is not that great, I need an external call to `ps` to get the process name for `select_process`.
Building a new constructor with the 2 additional parameters would probably be cleaner, I'd like some opinions.

Some strings can be i18n for sure, but I'd like to have a decent version before putting `_()` everywhere.

The 1st commit is actually a bugfix: when GC tries to attach to a process it can't read it will alert the user, but then proceeded to set labels and send commands as if it could attach.
The 2nd is just an unrelated typos fix (po files not regenerated)