### PR TITLE
Misc changes for scanmem cmdline options [REVIEW NEEDED]

### DIFF
--- a/main.c
+++ b/main.c
@@ -68,7 +68,7 @@ static void parse_parameter(int argc, char ** argv)
     bool done = false;
     /* process command line */
     while (!done) {
-        switch (getopt_long(argc, argv, "vhbdp:", longopts, &optindex)) {
+        switch (getopt_long(argc, argv, "vhdp:", longopts, &optindex)) {
             case 'p':
                 globals.target = (pid_t) strtoul(optarg, &end, 0);
 

--- a/main.c
+++ b/main.c
@@ -110,12 +110,12 @@ static void parse_parameter(int argc, char ** argv)
 
 int main(int argc, char **argv)
 {
+    parse_parameter(argc, argv);
+
     if (getuid() != 0)
     {
-        show_error("*** YOU ARE NOT RUNNING scanmem AS ROOT, IT MAY NOT WORK WELL. ***\n\n");
+        show_warn("*** YOU ARE NOT RUNNING scanmem AS ROOT, IT MAY NOT WORK WELL. ***\n\n");
     }
-    
-    parse_parameter(argc, argv);
 
     int ret = EXIT_SUCCESS;
     globals_t *vars = &globals;

--- a/main.c
+++ b/main.c
@@ -80,10 +80,10 @@ static void parse_parameter(int argc, char ** argv)
                 break;
             case 'v':
                 printversion(stdout);
-                exit(EXIT_FAILURE);
+                exit(EXIT_SUCCESS);
             case 'h':
                 printhelp();
-                exit(EXIT_FAILURE);
+                exit(EXIT_SUCCESS);
             case 'd':
                 globals.options.debug = 1;
                 break;

--- a/main.c
+++ b/main.c
@@ -39,8 +39,6 @@
 /* print quick usage message to stderr */
 static void printhelp()
 {
-    printversion(stderr);
-
     show_user("Usage: scanmem [OPTION]... [PID]\n"
             "Interactively locate and modify variables in an executing process.\n"
             "\n"

--- a/main.c
+++ b/main.c
@@ -79,7 +79,7 @@ static void parse_parameter(int argc, char ** argv)
                 }
                 break;
             case 'v':
-                printversion(stderr);
+                printversion(stdout);
                 exit(EXIT_FAILURE);
             case 'h':
                 printhelp();

--- a/main.c
+++ b/main.c
@@ -47,6 +47,7 @@ static void printhelp()
             "-p, --pid=pid\t\tset the target process pid\n"
             "-h, --help\t\tprint this message\n"
             "-v, --version\t\tprint version information\n"
+            "-d, --debug\t\tenable debug mode\n"
             "\n"
             "scanmem is an interactive debugging utility, enter `help` at the prompt\n"
             "for further assistance.\n"


### PR DESCRIPTION
Another not-ready-to-merge PR.

This contains a lot of small changes to the cmdline options of scanmem.
The maintainer may not like them all, so they are each in their tiny commit, so @sriemer can choose what he likes and I can squash only the needed ones together, write a decent message and submit them.

Some commentary:
20d8ff8 : I don't really need to be root to get help/version, don't scream at me. Also not being root should be a warning, there are systems without the paranoid ptrace protection by default (e.g. Debian)
cc126be : Self explanatory
Rest: exit signals, out streams and what is printed are modelled after GNU `grep`.
I really don't need the version when I just want to look the cmdline options.
