### PR TITLE
scanmem.1: Explain why scanmem requires root privileges

### DIFF
--- a/scanmem.1
+++ b/scanmem.1
@@ -39,12 +39,14 @@ this function is a good demonstration of how to use
 .SH USAGE
 .B scanmem
 should be invoked with the process id of the program you wish to debug as an argument. Once
-started, scanmem accepts interactive commands. These are described below, however entering
+started,
+.B scanmem
+accepts interactive commands. These are described below, however entering
 .IR help
 at the
 .B >
 prompt will allow you to access
-.B scanmem's
+.BR scanmem "'s"
 online documentation.
 
 The
@@ -155,7 +157,7 @@ in memory if the scan data type is set to "string".
 .B update
 
 Scans the current process, getting the current values of all matches. These values can be viewed with
-.BR list ", and are also the old values that scanmem compares to when using"
+.BR list ", and are also the old values that " scanmem " compares to when using"
 .BR > ", " < ", or " = "."
 This command is equivalent to a search command that all current results match.
 
@@ -221,7 +223,9 @@ Manually set the value of the variable at the specified address.
 
 Names of
 .I value_type
-are subject to change in different versions of scanmem, see more info using the `help write` command.
+are subject to change in different versions of
+.BR scanmem ","
+see more info using the `help write` command.
 
 .B dump
 .I address length [filename]
@@ -330,7 +334,9 @@ Please enter current value, or "help" for other commands.
 The 0 in the
 .B scanmem
 prompt indicates we currently have no candidates, so I enter how much gold I
-currently have (58 pieces) and let scanmem find the potential candidates.
+currently have (58 pieces) and let
+.B scanmem
+find the potential candidates.
 
 
 .nf
@@ -371,8 +377,9 @@ unlikely for a very old command line game. We could make
 .B scanmem
 eliminate these manually using the
 .B delete
-command, however just waiting until the amount of gold changes and telling scanmem the
-new value should be enough. I find some more gold, and tell
+command, however just waiting until the amount of gold changes and telling
+.B scanmem
+the new value should be enough. I find some more gold, and tell
 .B scanmem
 the new value, 83.
 
@@ -431,7 +438,8 @@ memory address of the gold value of the current game run.
 
 .B scanmem
 has been tested on multiple large programs, including the 3d shoot-em-up quake3 linux.
-Scanmem is also tested on ARM platforms and comes with Android support since version 0.16.
+.B scanmem
+is also tested on ARM platforms and comes with Android support since version 0.16.
 
 Obviously,
 .B scanmem

--- a/scanmem.1
+++ b/scanmem.1
@@ -314,8 +314,13 @@ Detach from the target program and exit immediately.
 .SH EXAMPLES
 Cheat at nethack, on systems where nethack is not installed sgid.
 
+.B ATTENTION: scanmem
+usually requires root privileges. See
+.B BUGS
+for details.
+
 .nf
-$ sudo scanmem `pidof nethack.tty`
+$ sudo scanmem `pgrep nethack`
 info: maps file located at /proc/14658/maps opened.
 info: 9 suitable regions found.
 Please enter current value, or "help" for other commands.
@@ -442,6 +447,22 @@ be loaded to different memory addresses at every game start. Advanced game train
 ugtrain are required to periodically refill variables is such memory regions.
 
 .SH BUGS
+
+.B scanmem
+usually requires root privileges for
+.BR ptrace (2)
+because security modules control ptrace() capabilities. On x86 and x86_64 there is usually
+the
+.B Yama
+security module providing the file
+.IR /proc/sys/kernel/yama/ptrace_scope "."
+It is available since Linux 3.4. If this file contains "1", then only parents may ptrace()
+their children without root privileges. This means that
+.B scanmem
+would have to run the game. This is not possible as this would require major design
+changes. So we run
+.B scanmem
+as root.
 
 The first scan can be very slow on large programs, this is not a problem for subsequent 
 scans as huge portions of the address space are usually eliminated. This could be improved


### PR DESCRIPTION
Many users are wondering why scanmem requires root privileges.
This is not on all distributions the case. Usually there is the
Yama security module controlling the ptrace() capabitlities since
Linux kernel 3.4. We can't avoid root privileges on such systems.
So document that in the BUGS section.

Also use the chance to replace "pidof nethack.tty" with "pgrep
nethack" as there are many variations how the nethack process is
called.

Reported-by: Andrea Stacchiotti (@12345ieee)