### PR TITLE
scanmem.[ch]: use ANSI prototyping

### DIFF
--- a/scanmem.c
+++ b/scanmem.c
@@ -94,7 +94,7 @@ out:
 }
 
 
-bool init()
+bool init(void)
 {
     globals_t *vars = &globals;
 
@@ -178,7 +178,7 @@ bool init()
 }
 
 /* for front-ends */
-void set_backend()
+void set_backend(void)
 {
     globals.options.backend = 1;
 }
@@ -190,22 +190,22 @@ void backend_exec_cmd(const char * commandline)
     fflush(stderr);
 }
 
-long get_num_matches()
+long get_num_matches(void)
 {
     return globals.num_matches;
 }
 
-const char * get_version()
+const char * get_version(void)
 {
     return PACKAGE_VERSION;
 }
 
-double get_scan_progress()
+double get_scan_progress(void)
 {
     return globals.scan_progress;
 }
 
-void reset_scan_progress()
+void reset_scan_progress(void)
 {
     globals.scan_progress = 0;
 }

--- a/scanmem.h
+++ b/scanmem.h
@@ -113,7 +113,7 @@ typedef struct {
 /* global settings */
 extern globals_t globals;
 
-bool init();
+bool init(void);
 
 /* ptrace.c */
 bool detach(pid_t target);


### PR DESCRIPTION
Always better.
