### PR TITLE
[rough] menu: shell backticks

### DIFF
--- a/menu.c
+++ b/menu.c
@@ -97,6 +97,100 @@ static char **commandcompletion(const char *text, int start, int end)
     return start ? NULL : rl_completion_matches(text, commandgenerator);
 }
 
+/*
+ * substitute `shell backtick` commands with their output.
+ */
+static bool shell_backticks(char **lineptr)
+{
+    char *line = *lineptr;
+    char *cmd_stpos, *cmd_endpos, *cmd, cmdout[BUFSIZ];
+    char *tmp, *tmp_st;
+    FILE *cmdfp;
+    size_t cmd_len, cmdout_len, line_len;
+
+    line_len = strlen(line);
+
+    cmd_stpos = line;
+st_was_escaped:
+    /* look for starting backtick */
+    if ((cmd_stpos = strchr(cmd_stpos, '`')) == NULL || *cmd_stpos == '\0')
+        return true; // no backticks, nothing to substitute
+    if (cmd_stpos != line && cmd_stpos[-1] == '\\') {
+        cmd_stpos++;
+        goto st_was_escaped;
+    }
+    if (*++cmd_stpos == '\0') { // hop over first backtick
+        fprintf(stderr, "error: no ending backtick in shell subsitution.\n");
+        return false;
+    }
+
+    cmd_endpos = cmd_stpos;
+end_was_escaped:
+    if ((cmd_endpos = strchr(cmd_endpos, '`')) == NULL || *cmd_endpos == '\0') {
+        fprintf(stderr, "error: no ending backtick in shell substitution.\n");
+        return false;
+    }
+    if (cmd_endpos[-1] == '\\') {
+        cmd_endpos++;
+        goto end_was_escaped;
+    }
+
+    if (cmd_endpos-1 == cmd_stpos)
+        return true; // XXX cleanup
+
+    cmd_len = cmd_endpos - cmd_stpos; // -1 for endtick
+    cmd = (char *)alloca(cmd_len);
+
+    /* copy shell command substr into cmd */
+    memcpy(cmd, cmd_stpos, cmd_len);
+    cmd[cmd_len] = '\0';
+    cmd_endpos++; // hop over ending backtick
+
+    /* fflush() in preparation for popen() */
+    fflush(stdout);
+
+    bool cmdok = true;
+    if ((cmdfp = popen(cmd, "r"))    == NULL ||
+        fgets(cmdout, BUFSIZ, cmdfp) == NULL) {
+        /*
+         * If the command fails for any reason, we will simply cut out
+         * the shell command from the line.
+         */
+        cmdok = false;
+    }
+
+    if (cmdok) {
+        pclose(cmdfp);
+        if ((tmp = strchr(cmdout, '\n')) != NULL)
+            *tmp = '\0';
+        cmdout_len = strlen(cmdout);
+    }
+
+    if ((tmp = malloc(line_len - (cmd_len+2)
+            + (cmdok ? cmdout_len : 0))) == NULL) { // +2 to include btick removal
+        fprintf(stderr, "error: no space for new line.\n");
+        return false;
+    }
+
+    tmp_st = tmp;
+
+    /* copy up to first backtick */
+    memcpy(tmp, line, cmd_stpos-1 - line); // -1 to rewind to first btick
+    tmp += cmd_stpos-1 - line;
+
+    /* copy shell output */
+    if (cmdok) {
+        memcpy(tmp, cmdout, cmdout_len);
+        tmp += cmdout_len;
+    }
+
+    /* copy from char after end backtick to end-of-string NUL */
+    memcpy(tmp, cmd_endpos, (line+line_len+2) - cmd_endpos); // +2 for NUL
+
+    *lineptr = tmp_st;
+
+    return true;
+}
 
 /*
  * getcommand() reads in a command using readline, and places a pointer to the
@@ -132,7 +226,7 @@ bool getcommand(globals_t * vars, char **line)
             ssize_t bytes_read = getline(line, &n, stdin);
             success = (bytes_read > 0);
             if (success)
-                (*line)[bytes_read-1] = '\0'; /* remove the trialing newline */
+                (*line)[bytes_read-1] = '\0'; /* remove the trailing newline */
         }
         if (!success) {
             /* EOF */
@@ -143,14 +237,13 @@ bool getcommand(globals_t * vars, char **line)
             }
         }
 
-        if (strlen(*line)) {
+        if (strlen(*line) && shell_backticks(line))
             break;
-        }
 
         free(*line);
     }
 
-    /* record this line to readline history */
+    /* record this line in readline history */
     add_history(*line);
     return true;
 }

--- a/menu.c
+++ b/menu.c
@@ -138,7 +138,7 @@ end_was_escaped:
     if (cmd_endpos-1 == cmd_stpos)
         return true; // XXX cleanup
 
-    cmd_len = cmd_endpos - cmd_stpos; // -1 for endtick
+    cmd_len = cmd_endpos - cmd_stpos;
     cmd = (char *)alloca(cmd_len);
 
     /* copy shell command substr into cmd */


### PR DESCRIPTION
This would be useful for commands like `pid`, for example:
```> pid `pidof command````
Not quite ready to be commited.