### PR TITLE
Gui: Improve filling speed of Scanresult liststore

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -376,7 +376,8 @@ class GameConqueror():
         addr = self.addcheat_address_input.get_text()
         try:
             addr = int(addr, 16)
-        except ValueError:
+            addr = GObject.Value(GObject.TYPE_UINT64, addr)
+        except (ValueError, OverflowError):
             self.show_error(_('Please enter a valid address.'))
             return False
 


### PR DESCRIPTION
First new feature for v0.17.
Uses lower level Gtk API to fill the Liststore much faster, allowing to x10 the results displayed.

The second commit takes advantage of the manual conversion needed for the 1st to check the manually added addresses as uints.

Finally closes #196 .