### PR TITLE
Only display 0 match when scan has been run

### DIFF
--- a/gui/backend.py
+++ b/gui/backend.py
@@ -29,7 +29,7 @@ class GameConquerorBackend():
         'sm_init' : (ctypes.c_bool, ),
         'sm_set_backend' : (None, ),
         'sm_backend_exec_cmd' : (None, ctypes.c_char_p),
-        'sm_get_num_matches' : (ctypes.c_long, ),
+        'sm_get_num_matches' : (ctypes.c_ulong, ),
         'sm_get_version' : (ctypes.c_char_p, ),
         'sm_get_scan_progress' : (ctypes.c_double, ),
         'sm_reset_scan_progress' : (None,)

--- a/menu.c
+++ b/menu.c
@@ -114,7 +114,14 @@ bool sm_getcommand(globals_t *vars, char **line)
 
     assert(vars != NULL);
 
-    snprintf(prompt, sizeof(prompt), "%ld> ", vars->num_matches);
+    if (vars->matches)
+    {
+        snprintf(prompt, sizeof(prompt), "%ld> ", vars->num_matches);
+    }
+    else
+    {
+        snprintf(prompt, sizeof(prompt), " > ");
+    }
 
     rl_readline_name = "scanmem";
     rl_attempted_completion_function = commandcompletion;

--- a/scanmem.c
+++ b/scanmem.c
@@ -200,7 +200,7 @@ void sm_backend_exec_cmd(const char *commandline)
     fflush(stderr);
 }
 
-long sm_get_num_matches(void)
+unsigned long sm_get_num_matches(void)
 {
     return sm_globals.num_matches;
 }

--- a/scanmem.h
+++ b/scanmem.h
@@ -71,7 +71,7 @@ typedef struct {
     unsigned exit:1;
     pid_t target;
     matches_and_old_values_array *matches;
-    long num_matches;
+    unsigned long num_matches;
     double scan_progress;
     list_t *regions;
     list_t *commands;              /* command handlers */
@@ -99,7 +99,7 @@ bool sm_init(void);
 void sm_printversion(FILE *outfd);
 void sm_set_backend(void);
 void sm_backend_exec_cmd(const char *commandline);
-long sm_get_num_matches(void);
+unsigned long sm_get_num_matches(void);
 const char *sm_get_version(void);
 double sm_get_scan_progress(void);
 void sm_reset_scan_progress(void);

--- a/targetmem.c
+++ b/targetmem.c
@@ -164,7 +164,7 @@ nth_match (matches_and_old_values_array *matches, unsigned n)
 
 matches_and_old_values_array *
 delete_by_region (matches_and_old_values_array *matches,
-                  long *num_matches, region_t *which, bool invert)
+                  unsigned long *num_matches, region_t *which, bool invert)
 {
     int reading_iterator = 0;
     matches_and_old_values_swath *reading_swath_index =

--- a/targetmem.h
+++ b/targetmem.h
@@ -130,7 +130,7 @@ void data_to_bytearray_text (char *buf, int buf_length,
 match_location nth_match (matches_and_old_values_array *matches, unsigned n);
 
 matches_and_old_values_array *delete_by_region (matches_and_old_values_array *array,
-                                                long *num_matches, region_t *which,
+                                                unsigned long *num_matches, region_t *which,
                                                 bool invert);
 
 static inline long


### PR DESCRIPTION
This PR aims to fix #229.

`num_matches` is now an `unsigned long` and the prompt display "0>" only after a scan. On init or reset, it displays "'space'>"

I did not introduce another boolean to track the reset status, the logic is based on the existence of `matches`.

Let me know if I need to update this PR.