### PR TITLE
Add a stop scan mechanism

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -150,6 +150,7 @@ class GameConqueror():
         self.input_box = self.builder.get_object('Value_Input')
 
         self.scan_button = self.builder.get_object('Scan_Button')
+        self.stop_button = self.builder.get_object('Stop_Button')
         self.reset_button = self.builder.get_object('Reset_Button')
 
         ###
@@ -286,7 +287,8 @@ class GameConqueror():
         self.disablelist.append(self.cheatlist_tv)
         self.disablelist.append(self.scanresult_tv)
         self.disablelist.append(self.builder.get_object('processGrid'))
-        self.disablelist.append(self.builder.get_object('searchGrid'))
+        self.disablelist.append(self.value_input)
+        self.disablelist.append(self.reset_button)
         self.disablelist.append(self.builder.get_object('buttonGrid'))
         self.disablelist.append(self.memoryeditor_window)
 
@@ -496,6 +498,10 @@ class GameConqueror():
 
     def Scan_Button_clicked_cb(self, button, data=None):
         self.do_scan()
+        return True
+
+    def Stop_Button_clicked_cb(self, button, data=None):
+        self.backend.set_stop_flag(True)
         return True
 
     def Reset_Button_clicked_cb(self, button, data=None):
@@ -981,6 +987,10 @@ class GameConqueror():
         # disable set of widgets interfering with the scan
         for wid in self.disablelist:
             wid.set_sensitive(False)
+        
+        # Replace scan_button with stop_button
+        self.scan_button.set_visible(False)
+        self.stop_button.set_visible(True)
 
         self.is_scanning = True
         # set scan options only when first scan, since this will reset backend
@@ -1004,6 +1014,10 @@ class GameConqueror():
         # enable set of widgets interfering with the scan
         for wid in self.disablelist:
             wid.set_sensitive(True)
+
+        # Replace stop_button with scan_button
+        self.stop_button.set_visible(False)
+        self.scan_button.set_visible(True)
 
         self.is_scanning = False
         self.update_scan_result()

--- a/gui/GameConqueror.xml
+++ b/gui/GameConqueror.xml
@@ -162,6 +162,11 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
     <property name="can_focus">False</property>
     <property name="icon_name">document-save</property>
   </object>
+  <object class="GtkImage" id="stop_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">stop</property>
+  </object>
   <object class="GtkImage" id="system_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -337,6 +342,22 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
                       </object>
                       <packing>
                         <property name="left_attach">3</property>
+                        <property name="top_attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="Stop_Button">
+                        <property name="width_request">32</property>
+                        <property name="height_request">32</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Stop scan</property>
+                        <property name="margin_right">1</property>
+                        <property name="image">stop_image</property>
+                        <signal name="clicked" handler="Stop_Button_clicked_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">2</property>
                         <property name="top_attach">0</property>
                       </packing>
                     </child>

--- a/gui/backend.py
+++ b/gui/backend.py
@@ -32,7 +32,8 @@ class GameConquerorBackend():
         'sm_get_num_matches' : (ctypes.c_ulong, ),
         'sm_get_version' : (ctypes.c_char_p, ),
         'sm_get_scan_progress' : (ctypes.c_double, ),
-        'sm_reset_scan_progress' : (None,)
+        'sm_reset_scan_progress' : (None,),
+        'sm_set_stop_flag' : (ctypes.c_bool, )
     }
 
     def __init__(self, libpath='libscanmem.so'):
@@ -78,3 +79,5 @@ class GameConquerorBackend():
     def reset_scan_progress(self):
         self.lib.sm_reset_scan_progress()
 
+    def set_stop_flag(self, stop_flag):
+        self.lib.sm_set_stop_flag(stop_flag)

--- a/ptrace.c
+++ b/ptrace.c
@@ -309,6 +309,7 @@ bool sm_checkmatches(globals_t *vars,
     int required_extra_bytes_to_record = 0;
     vars->num_matches = 0;
     vars->scan_progress = 0.0;
+    vars->stop_flag = false;
     
     if (sm_choose_scanroutine(vars->options.scan_data_type, match_type) == false)
     {
@@ -379,6 +380,8 @@ bool sm_checkmatches(globals_t *vars,
                     /* for user, just print a dot */
                     print_a_dot();
                 }
+                /* stop scanning if asked to */
+                if (vars->stop_flag) break;
             }
         }
         ++bytes_scanned;
@@ -504,6 +507,7 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
         total_scan_bytes += ((region_t *)n->data)->size;
 
     vars->scan_progress = 0.0;
+    vars->stop_flag = false;
     n = vars->regions->head;
 
     /* check every memory region */
@@ -625,16 +629,20 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
                     print_a_dot();
                     /* for front-end, update percentage */
                     vars->scan_progress += progress_per_dot;
+                    /* stop scanning if asked to */
+                    if (vars->stop_flag) break;
                 }
             }
         }
 
-        vars->scan_progress += progress_per_dot;
-        n = n->next;
-        show_user("ok\n");
 #if HAVE_PROCMEM
         free(data);
 #endif
+        vars->scan_progress += progress_per_dot;
+        /* stop scanning if asked to */
+        if (vars->stop_flag) break;
+        n = n->next;
+        show_user("ok\n");
     }
 
     /* tell front-end we've done */

--- a/scanmem.c
+++ b/scanmem.c
@@ -53,6 +53,7 @@ globals_t sm_globals = {
     NULL,                       /* matches */
     0,                          /* match count */
     0,                          /* scan progress */
+    false,                      /* stop flag */
     NULL,                       /* regions */
     NULL,                       /* commands */
     NULL,                       /* current_cmdline */
@@ -218,4 +219,9 @@ double sm_get_scan_progress(void)
 void sm_reset_scan_progress(void)
 {
     sm_globals.scan_progress = 0;
+}
+
+void sm_set_stop_flag(bool stop_flag)
+{
+    sm_globals.stop_flag = stop_flag;
 }

--- a/scanmem.h
+++ b/scanmem.h
@@ -73,6 +73,7 @@ typedef struct {
     matches_and_old_values_array *matches;
     unsigned long num_matches;
     double scan_progress;
+    bool stop_flag;
     list_t *regions;
     list_t *commands;              /* command handlers */
     const char *current_cmdline;   /* the command being executed */
@@ -103,6 +104,7 @@ unsigned long sm_get_num_matches(void);
 const char *sm_get_version(void);
 double sm_get_scan_progress(void);
 void sm_reset_scan_progress(void);
+void sm_set_stop_flag(bool stop_flag);
 
 /* ptrace.c */
 bool sm_detach(pid_t target);


### PR DESCRIPTION
Adds a global variable, editable by the front-end and periodically read by the back-end during scan, to stop the current scan and retain only the values obtained till then.
Also adds the gui button to actually use the feature.

Obvious use case: scanning `firefox` takes a couple of minutes, if I got the value wrong I want to terminate the scan ASAP.

The checking is very coarse on purpose, to have minimal impact on the scan.

This is an important feature for me, planned for v0.17, as it changes the API.

@sriemer and @bkazemi , see any problem?