### PR TITLE
libscanmem: fix grammatical errors in comments

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -42,7 +42,7 @@
 /*
  * sm_registercommand - add the command and a pointer to its handler to the commands list.
  *
- * so that free(data) works when destroying the list, I just concatenate the string
+ * So that free(data) works when destroying the list, I just concatenate the string
  * with the command structure. I could have used a static vector of commands, but this
  * way I can add aliases and macros at runtime (planned in future).
  *
@@ -124,7 +124,7 @@ bool sm_execcommand(globals_t *vars, const char *commandline)
     if (argv[0] == NULL) {
         free(argv);
         
-        /* legal i guess, just dont do anything */
+        /* legal I guess, just don't do anything */
         return true;
     }
     

--- a/endianness.h
+++ b/endianness.h
@@ -33,7 +33,7 @@
 #include "value.h"
 #include "config.h"
 
-/* True if host is big endian */
+/* true if host is big endian */
 #ifdef WORDS_BIGENDIAN
 static const bool big_endian = true;
 #else

--- a/getline.c
+++ b/getline.c
@@ -38,7 +38,7 @@ ssize_t getline(char **lineptr, size_t *n, FILE *stream)
     char *lptr;
     size_t len = 0;
 
-    /* Check for invalid arguments */
+    /* check for invalid arguments */
     if (lineptr == NULL || n == NULL) {
         errno = EINVAL;
         return -1;
@@ -46,13 +46,13 @@ ssize_t getline(char **lineptr, size_t *n, FILE *stream)
 
     lptr = fgetln(stream, &len);
     if (lptr == NULL) {
-        /* Invalid stream */
+        /* invalid stream */
         errno = EINVAL;
         return -1;
     }
 
     /*
-     * getline() returns a null byte ('\0') terminated C string
+     * getline() returns a null byte ('\0') terminated C string,
      * but fgetln() returns characters without '\0' termination
      */
     if (*lineptr == NULL) {
@@ -60,7 +60,7 @@ ssize_t getline(char **lineptr, size_t *n, FILE *stream)
         goto alloc_buf;
     }
 
-    /* Realloc the original pointer */
+    /* realloc the original pointer */
     if (*n < len + 1) {
         free(*lineptr);
 
@@ -73,7 +73,7 @@ alloc_buf:
         }
     }
 
-    /* Copy over the string */
+    /* copy over the string */
     memcpy(*lineptr, lptr, len);
     (*lineptr)[len] = '\0';
 

--- a/handlers.c
+++ b/handlers.c
@@ -57,11 +57,11 @@
 
 /*
  * This file defines all the command handlers used, each one is registered using
- * registercommand(), and when a matching command is entered, the commandline is
+ * registercommand(). When a matching command is entered, the commandline is
  * tokenized and parsed into an argv/argc.
  * 
  * argv[0] will contain the command entered, so one handler can handle multiple
- * commands by checking whats in there, but you still need seperate documentation
+ * commands by checking what's in there. You still need seperate documentation
  * for each command when you register it.
  *
  * Most commands will also need some documentation, see handlers.h for the format.
@@ -127,7 +127,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
     /* parse every block into a settings struct */
     for (block = 0; block < argc - 1; block++) {
 
-        /* first seperate the block into matches and value, which are separated by '=' */
+        /* first separate the block into matches and value, which are separated by '=' */
         if ((settings[block].value = strchr(argv[block + 1], '=')) == NULL) {
 
             /* no '=' found, whole string must be the value */
@@ -161,7 +161,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                 show_error("trailing garbage after delay count, `%s`.\n", settings[block].value);
                 return false;
             } else if (settings[block].seconds == 0) {
-                /* 10=24/0 disables continous mode */
+                /* 10=24/0 disables continuous mode */
                 show_info("you specified a zero delay, disabling continuous mode.\n");
             } else {
                 /* valid delay count seen and understood */
@@ -197,7 +197,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
         /* for every settings struct */
         for (block = 0; block < argc - 1; block++) {
 
-            /* check if this block has anything to do this iteration */
+            /* check if this block has anything to do in this iteration */
             if (seconds != 1) {
                 /* not the first iteration (all blocks get executed first iteration) */
 
@@ -222,7 +222,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                 /* create local copy of the matchids for strtok() to modify */
                 lmatches = strdupa(settings[block].matchids);
 
-                /* now seperate each match, spearated by commas */
+                /* now separate each match, separated by commas */
                 while ((id = strtok(lmatches, ",")) != NULL) {
                     match_location loc;
 
@@ -232,7 +232,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                     /* parse this id */
                     num = strtoul(id, &end, 0x00);
 
-                    /* check that succeeded */
+                    /* check if that succeeded */
                     if (*id == '\0' || *end != '\0') {
                         show_error("could not parse match id `%s`\n", id);
                         goto fail;
@@ -275,7 +275,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                 /* user wants to set all matches */
                 while (reading_swath_index->first_byte_in_child) {
 
-                    /* Only actual matches are considered */
+                    /* only actual matches are considered */
                     if (flags_to_max_width_in_bytes(reading_swath_index->data[reading_iterator].match_info) > 0)
                     {
                         void *address = remote_address_of_nth_element(reading_swath_index, reading_iterator /* ,MATCHES_AND_VALUES */);
@@ -297,7 +297,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                         }
                     }
                      
-                     /* Go on to the next one... */
+                     /* go on to the next one... */
                     ++reading_iterator;
                     if (reading_iterator >= reading_swath_index->number_of_bytes)
                     {
@@ -333,7 +333,7 @@ fail:
 bool handler__list(globals_t *vars, char **argv, unsigned argc)
 {
     unsigned i = 0;
-    int buf_len = 128; /* will be realloc later if necessary */
+    int buf_len = 128; /* will be realloc'd later if necessary */
     element_t *np = NULL;
     char *v = malloc(buf_len);
     if (v == NULL)
@@ -360,7 +360,7 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
 
         match_flags flags = reading_swath_index->data[reading_iterator].match_info;
 
-        /* Only actual matches are considered */
+        /* only actual matches are considered */
         if (flags_to_max_width_in_bytes(flags) > 0)
         {
             switch(vars->options.scan_data_type)
@@ -368,7 +368,7 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
             case BYTEARRAY:
                 ; /* cheat gcc */ 
                 buf_len = flags.bytearray_length * 3 + 32;
-                v = realloc(v, buf_len); /* for each byte and the suffix', this should be enough */
+                v = realloc(v, buf_len); /* for each byte and the suffix, this should be enough */
 
                 if (v == NULL)
                 {
@@ -408,7 +408,7 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
             unsigned long match_off = 0;
             const char *region_type = "??";
             /* get region info belonging to the match -
-             * note: we assume the regions list and matches to be sorted
+             * note: we assume the regions list and matches are sorted
              */
             while (np) {
                 region_t *region = np->data;
@@ -426,7 +426,7 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
                     i++, address_ul, region_id, match_off, region_type, v);
         }
 
-        /* Go on to the next one... */
+        /* go on to the next one... */
         ++reading_iterator;
         if (reading_iterator >= reading_swath_index->number_of_bytes)
         {
@@ -466,7 +466,7 @@ bool handler__delete(globals_t * vars, char **argv, unsigned argc)
     
     if (loc.swath)
     {
-        /* It is not convenient to check whether anything else relies on this,
+        /* it is not convenient to check whether anything else relies on this,
            so just mark it as not a REAL match */
         zero_match_flags(&loc.swath->data[loc.index].match_info);
         vars->num_matches--;
@@ -584,7 +584,7 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc)
         /* create a copy of the argument for strtok(), +1 to skip '!' */
         block = strdupa(argv[1] + 1);
         
-        /* check for lone '!' */
+        /* check for a lone '!' */
         if (*block == '\0') {
             show_error("inverting an empty set, maybe try `reset` instead?\n");
             return false;
@@ -611,7 +611,7 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc)
         /* attempt to parse as a regionid */
         id = strtoul(idstr, &end, 0x00);
 
-        /* check that worked, "1,abc,4,,5,6foo" */
+        /* check if that worked, "1,abc,4,,5,6foo" */
         if (*end != '\0' || *idstr == '\0') {
             show_error("could not parse argument %s.\n", idstr);
             if (invert) {
@@ -626,7 +626,7 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc)
             return false;
         }
         
-        /* initialise list pointers */
+        /* initialize list pointers */
         np = vars->regions->head;
         pp = NULL;
         
@@ -734,7 +734,7 @@ bool handler__lregions(globals_t * vars, char **argv, unsigned argc)
         show_info("no regions are known.\n");
     }
     
-    /* print a list of regions that are searched */
+    /* print a list of regions that have been searched */
     while (np) {
         region_t *region = np->data;
 
@@ -752,7 +752,7 @@ bool handler__lregions(globals_t * vars, char **argv, unsigned argc)
     return true;
 }
 
-/* the name of the function is for history reason, now GREATERTHAN & LESSTHAN are also handled by this function */
+/* the name of the function is for historical reasons, now `GREATERTHAN` and `LESSTHAN` are also handled by this function */
 bool handler__decinc(globals_t * vars, char **argv, unsigned argc)
 {
     uservalue_t val;
@@ -1045,7 +1045,7 @@ bool handler__exit(globals_t *vars, char **argv, unsigned argc)
     return true;
 }
 
-#define DOC_COLUMN  11           /* which column descriptions start on with help command */
+#define DOC_COLUMN  11           /* which column descriptions start on with the help command */
 
 bool handler__help(globals_t *vars, char **argv, unsigned argc)
 {
@@ -1082,7 +1082,7 @@ bool handler__help(globals_t *vars, char **argv, unsigned argc)
 
         /* just `help` with no argument */
         if (argv[1] == NULL) {
-            /* NULL shortdoc means dont print in help listing */
+            /* NULL shortdoc means don't print in the help listing */
             if (command->shortdoc == NULL) {
                 np = np->next;
                 continue;
@@ -1197,7 +1197,7 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
     
     loc = nth_match(vars->matches, id);
 
-    /* check this is a valid match-id */
+    /* check that this is a valid match-id */
     if (!loc.swath) {
         show_error("you specified a non-existent match `%u`.\n", id);
         show_info("use \"list\" to list matches, or \"help\" for other commands.\n");

--- a/handlers.h
+++ b/handlers.h
@@ -30,11 +30,11 @@
  * LONGDOC's are detailed descriptions (shown with `help command`) (wrap them before column 80).
  * 
  * The DOC's are passed to the registercommand() routine, and are read by the help
- * command. You can define SHRTDOC to NULL and help will not print it.
- * However, a NULL longdoc will print "missing documentation" if specific help is requested,
- * if you really dont want it to print anything, use "".
+ * command. You can define SHRTDOC as NULL and help will not print it.
+ * However, a NULL longdoc will print "missing documentation" if specific help is requested.
+ * If you really don't want it to print anything, use "".
  *
- * Each handler is passed an argv and argc, argv[0] is the command called, along with
+ * Each handler is passed an argv and argc, argv[0] being the command called. Also passed is
  * a pointer to the global settings structure, which contains various settings and lists
  * that handlers are allowed to change. One handler can handle multiple commands, but
  * you need register each command with its own documentation.

--- a/interrupt.h
+++ b/interrupt.h
@@ -22,11 +22,11 @@
 
 /* small header file to manage interrupted commands */
 
-static sigjmp_buf jmpbuf;       /* used when aborting a command due to interrupt */
+static sigjmp_buf jmpbuf;       /* used when aborting a command due to an interrupt */
 static sighandler_t oldsig;     /* reinstalled before longjmp */
 static unsigned intused;
 
-/* signal handler to handle interrupt during a commands */
+/* signal handler used to handle an interrupt during commands */
 static void interrupted(int n)
 {
     (void) n;

--- a/list.c
+++ b/list.c
@@ -68,7 +68,7 @@ int l_append(list_t * list, element_t * element, void *data)
         list->head = n;
     } else {
 
-        /* insertion in the middle of a list */
+        /* insertion at the middle of a list */
         if (element->next == NULL) {
             list->tail = n;
         }

--- a/main.c
+++ b/main.c
@@ -185,7 +185,7 @@ int main(int argc, char **argv)
             break;
         }
 
-        /* sm_execcommand() returning failure is not fatal, just the command could not complete. */
+        /* sm_execcommand() returning failure is not fatal, it just means the command could not complete. */
         if (sm_execcommand(vars, line) == false) {
             if (vars->target == 0) {
                 show_user("Enter the pid of the process to search using the \"pid\" command.\n");

--- a/maps.c
+++ b/maps.c
@@ -101,7 +101,7 @@ bool sm_readmaps(pid_t target, list_t *regions)
                 goto error;
             }
             
-            /* initialise to zero */
+            /* initialize to zero */
             memset(filename, '\0', len);
 
             /* parse each line */
@@ -224,7 +224,7 @@ bool sm_readmaps(pid_t target, list_t *regions)
                     goto error;
                 }
 
-                /* initialise this region */
+                /* initialize this region */
                 map->flags.read = true;
                 map->flags.write = true;
                 map->start = (void *) start;

--- a/maps.h
+++ b/maps.h
@@ -27,7 +27,7 @@
 
 #include "list.h"
 
-/* determine what regions we need */
+/* determine which regions we need */
 typedef enum {
     REGION_ALL,                            /* each of them */
     REGION_HEAP_STACK_EXECUTABLE,          /* heap, stack, executable */
@@ -47,7 +47,7 @@ extern const char *region_type_names[];
 
 /* a region obtained from /proc/pid/maps, these are searched for matches */
 typedef struct {
-    void *start;             /* start address. Hack: If HAVE_PROCMEM, this is actually an (unsigned long) offset into /proc/{pid}/mem */
+    void *start;             /* Start address. Hack: If HAVE_PROCMEM is defined, this is actually an (unsigned long) offset into /proc/{pid}/mem */
     unsigned long size;              /* size */
     region_type_t type;
     unsigned long load_addr;         /* e.g. load address of the executable */

--- a/menu.c
+++ b/menu.c
@@ -102,8 +102,8 @@ static char **commandcompletion(const char *text, int start, int end)
 
 
 /*
- * sm_getcommand() reads in a command using readline, and places a pointer to
- * the read string into *line, _which must be free'd by caller_.
+ * sm_getcommand() reads in a command using readline and places a pointer to
+ * the read string into *line, _which must be free'd by caller.
  * returns true on success, or false on error.
  */
 
@@ -126,7 +126,7 @@ bool sm_getcommand(globals_t *vars, char **line)
     while (true) {
         if (vars->options.backend == 0)
         {
-            /* for normal user, read in the next command using readline library */
+            /* for normal users, read in the next command using readline library */
             success = ((*line = readline(prompt)) != NULL);
         }
         else 
@@ -139,7 +139,7 @@ bool sm_getcommand(globals_t *vars, char **line)
             ssize_t bytes_read = getline(line, &n, stdin);
             success = (bytes_read > 0);
             if (success)
-                (*line)[bytes_read-1] = '\0'; /* remove the trialing newline */
+                (*line)[bytes_read-1] = '\0'; /* remove the trailing newline */
         }
         if (!success) {
             /* EOF */

--- a/scanmem.c
+++ b/scanmem.c
@@ -71,7 +71,7 @@ globals_t sm_globals = {
     }
 };
 
-/* signal handler - Use async-signal-safe functions ONLY! */
+/* signal handler - use async-signal safe functions ONLY! */
 static void sighandler(int n)
 {
     const char err_msg[] = "error: \nKilled by signal ";
@@ -121,13 +121,13 @@ bool sm_init(void)
         (void) signal(SIGTERM, sighandler);
     }
 
-    /* linked list of commands, and function pointers to their handlers */
+    /* linked list of commands and function pointers to their handlers */
     if ((vars->commands = l_init()) == NULL) {
         show_error("sorry, there was a memory allocation error.\n");
         return false;
     }
 
-    /* NULL shortdoc means dont display this command in `help` listing */
+    /* NULL shortdoc means don't display this command in `help` listing */
     sm_registercommand("set", handler__set, vars->commands, SET_SHRTDOC,
                        SET_LONGDOC);
     sm_registercommand("list", handler__list, vars->commands, LIST_SHRTDOC,

--- a/scanmem.h
+++ b/scanmem.h
@@ -82,7 +82,7 @@ typedef struct {
         unsigned short alignment;
         unsigned short debug;
         unsigned short backend;    /* if 1, scanmem will work as a backend and
-                                      output would be more machine-readable */
+                                      output will be more machine-readable */
 
         /* options that can be changed during runtime */
         scan_data_type_t scan_data_type;

--- a/scanroutines.c
+++ b/scanroutines.c
@@ -377,7 +377,7 @@ extern inline int scan_routine_STRING_EQUALTO SCAN_ROUTINE_ARGUMENTS
 /*-------------------------*/
 /* Any-xxx types specifiec */
 /*-------------------------*/
-/* this is for anynumber, anyinteger, anyfloat */
+/* this is for anynumber, anyinteger and anyfloat */
 #define DEFINE_ANYTYPE_ROUTINE(MATCHTYPENAME) \
     extern inline int scan_routine_ANYINTEGER_##MATCHTYPENAME SCAN_ROUTINE_ARGUMENTS \
     { \

--- a/scanroutines.h
+++ b/scanroutines.h
@@ -68,8 +68,8 @@ typedef int (*scan_routine_t)(const value_t *new_value, const value_t *old_value
 extern scan_routine_t sm_scan_routine;
 
 /* 
- * choose the global scanroutine according to the given parameters, g_scan_routine will be set 
- * return whether a proper routine has been found
+ * Choose the global scanroutine according to the given parameters. g_scan_routine will be set to
+ * return whether a proper routine has been found.
  */
 bool sm_choose_scanroutine(scan_data_type_t dt, scan_match_type_t mt);
 

--- a/show_message.h
+++ b/show_message.h
@@ -20,16 +20,16 @@
 */
 
 /*
- * This file declares all types of output functions, in order to provide well-formatted messages that a front-end can understand
+ * This file declares all types of output functions, in order to provide well-formatted messages that a front-end can understand.
  *
- * Basically, all data go through stdout, and all message (to user or to front-end) go through stderr
+ * Basically, all data goes through stdout, and all messages (to user or front-end) go through stderr.
  *
  * In stderr:
- *  all messages prefixed with 'error:' will be considered fatal error, front-end may notify user to re-start backend
- *  all messages prefixed with 'warn:' will be considered nonfatal error
+ *  all messages prefixed with 'error:' will be considered a fatal error; front-end may notify user to restart backend
+ *  all messages prefixed with 'warn:' will be considered a nonfatal error.
  *  all messages prefixed with 'info:' will be ignored (by the front-end)
  *
- *  To display message to user only, use show_user, nothing will be prepended, and the message will be ignore if scanmem is running as a backend
+ *  To display messages to user only, use show_user; nothing will be prepended, and the message will be ignored if scanmem is running as a backend.
  */
 
 #ifndef SHOW_MESSAGE_H

--- a/targetmem.c
+++ b/targetmem.c
@@ -36,7 +36,7 @@
 matches_and_old_values_array *
 allocate_array (matches_and_old_values_array *array, unsigned long max_bytes)
 {
-    /* Make enough space for the array header and a null first swath. */
+    /* make enough space for the array header and a null first swath */
     unsigned long bytes_to_allocate =
         sizeof(matches_and_old_values_array) +
         sizeof(matches_and_old_values_swath);
@@ -72,7 +72,7 @@ null_terminate (matches_and_old_values_array *array,
                     (void *)array);
 
     if (bytes_needed < array->bytes_allocated) {
-        /* Reduce array to its final size */
+        /* reduce array to its final size */
         if (!(array = realloc(array, bytes_needed)))
             return NULL;
 
@@ -137,7 +137,7 @@ nth_match (matches_and_old_values_array *matches, unsigned n)
         return (match_location){NULL, 0};
 
     while (reading_swath_index->first_byte_in_child) {
-        /* Only actual matches are considered */
+        /* only actual matches are considered */
         if (flags_to_max_width_in_bytes(
                 reading_swath_index->data[reading_iterator].match_info) > 0) {
 
@@ -147,7 +147,7 @@ nth_match (matches_and_old_values_array *matches, unsigned n)
             ++i;
         }
 
-        /* Go on to the next one... */
+        /* go on to the next one... */
         ++reading_iterator;
         if (reading_iterator >= reading_swath_index->number_of_bytes) {
             reading_swath_index =
@@ -202,12 +202,12 @@ delete_by_region (matches_and_old_values_array *matches,
                                       writing_swath_index, address,
                                       &reading_swath_index->data[reading_iterator]);
 
-            /* Actual matches are recorded */
+            /* actual matches are recorded */
             if (flags_to_max_width_in_bytes(flags) > 0)
                 ++(*num_matches);
         }
 
-        /* Go on to the next one... */
+        /* go on to the next one... */
         ++reading_iterator;
         if (reading_iterator >= reading_swath.number_of_bytes) {
 

--- a/targetmem.h
+++ b/targetmem.h
@@ -176,7 +176,7 @@ allocate_enough_to_reach (matches_and_old_values_array *array,
     } else {
         matches_and_old_values_array *original_location = array;
 
-        /* Allocate twice as much each time,
+        /* allocate twice as much each time,
            so we don't have to do it too often */
         unsigned long bytes_to_allocate = array->bytes_allocated;
         while (bytes_to_allocate < bytes_needed)
@@ -185,7 +185,7 @@ allocate_enough_to_reach (matches_and_old_values_array *array,
         show_debug("to_allocate %ld, max %ld\n", bytes_to_allocate,
                    array->max_needed_bytes);
 
-        /* Sometimes we know an absolute max that we will need */
+        /* sometimes we know an absolute max that we will need */
         if (array->max_needed_bytes < bytes_to_allocate) {
             assert(array->max_needed_bytes >= bytes_needed);
             bytes_to_allocate = array->max_needed_bytes;
@@ -209,7 +209,7 @@ allocate_enough_to_reach (matches_and_old_values_array *array,
     }
 }
 
-/* Returns a pointer to the swath to which the element was added -
+/* returns a pointer to the swath to which the element was added -
    i.e. the last swath in the array after the operation */
 static inline matches_and_old_values_swath *
 add_element (matches_and_old_values_array **array,
@@ -219,7 +219,7 @@ add_element (matches_and_old_values_array **array,
     if (swath->number_of_bytes == 0) {
         assert(swath->first_byte_in_child == NULL);
 
-        /* We have to overwrite this as a new swath */
+        /* we have to overwrite this as a new swath */
         *array = allocate_enough_to_reach(*array, (void *)swath +
             sizeof(matches_and_old_values_swath) +
             sizeof(old_value_and_match_info), &swath);
@@ -238,7 +238,7 @@ add_element (matches_and_old_values_array **array,
             sizeof(old_value_and_match_info);
 
         if (local_address_excess >= needed_size) {
-            /* It is most memory-efficient to start a new swath */
+            /* it is most memory-efficient to start a new swath */
             *array = allocate_enough_to_reach(*array,
                 local_address_beyond_last_element(swath) +
                 sizeof(matches_and_old_values_swath) +
@@ -249,7 +249,7 @@ add_element (matches_and_old_values_array **array,
             swath->number_of_bytes = 0;
 
         } else {
-            /* It is most memory-efficient to write over the intervening
+            /* it is most memory-efficient to write over the intervening
                space with null values */
             *array = allocate_enough_to_reach(*array,
                 local_address_beyond_last_element(swath) +
@@ -272,7 +272,7 @@ add_element (matches_and_old_values_array **array,
         }
     }
 
-    /* Add me */
+    /* add me */
     *(old_value_and_match_info *)local_address_beyond_last_element(swath) =
         *(old_value_and_match_info *)new_element;
     ++swath->number_of_bytes;
@@ -280,9 +280,9 @@ add_element (matches_and_old_values_array **array,
     return swath;
 }
 
-/* only at most sizeof(int64_t) bytes will be read,
-   if more bytes are needed (e.g. bytearray),
-   read them separatedly (for performance) */
+/* Only at most sizeof(int64_t) bytes will be read.
+   If more bytes are needed (e.g. bytearray),
+   read them separately (for performance) */
 static inline value_t
 data_to_val_aux (matches_and_old_values_swath *swath,
                  long index, long swath_length)

--- a/value.c
+++ b/value.c
@@ -88,7 +88,7 @@ void valtostr(const value_t *val, char *str, size_t n)
 
     return;
 err:
-    /* always print a value and a type to not crash front-ends */
+    /* always print a value and a type to not crash the GUI */
     strncpy(str, "unknown, [unknown]", n);
 }
 
@@ -233,7 +233,7 @@ bool parse_uservalue_float(const char *nptr, uservalue_t * val)
     if ((errno != 0) || (*endptr != '\0'))
         return false;
     
-    /* I'm not sure how to distinguish float & double, but I guess it's not necessary here */
+    /* I'm not sure how to distinguish between float and double, but I guess it's not necessary here */
     val->flags.f32b = val->flags.f64b = 1;
     val->float32_value = (float) num;
     val->float64_value =  num;   
@@ -255,7 +255,7 @@ int flags_to_max_width_in_bytes(match_flags flags)
             else if (flags.u32b || flags.s32b || flags.f32b) return 4;
             else if (flags.u16b || flags.s16b              ) return 2;
             else if (flags.u8b  || flags.s8b               ) return 1;
-            else    /* It can't be a variable of any size */ return 0;
+            else    /* it can't be a variable of any size */ return 0;
             break;
     }
 }

--- a/value.h
+++ b/value.h
@@ -34,7 +34,7 @@
 /* some routines for working with value_t structures */
 
 /* this is memory-efficient but DANGEROUS */
-/* always keep in mind that don't mess up with bytearray_length or string_length when scanning for BYTEARRAY of STRING */
+/* always keep in mind to not mess up with bytearray_length or string_length when scanning for BYTEARRAY of STRING */
 typedef union {
     struct __attribute__ ((packed)) {
         unsigned  u8b:1;        /* could be an unsigned  8-bit variable (e.g. unsigned char)      */
@@ -48,15 +48,15 @@ typedef union {
         unsigned f32b:1;        /* could be a 32-bit floating point variable (i.e. float)         */
         unsigned f64b:1;        /* could be a 64-bit floating point variable (i.e. double)        */
 
-        unsigned ineq_forwards:1; /* Whether this value has matched inequalities used the normal way */
-        unsigned ineq_reverse:1; /* Whether this value has matched inequalities in reverse */
+        unsigned ineq_forwards:1; /* whether this value has matched inequalities used the normal way */
+        unsigned ineq_reverse:1; /* whether this value has matched inequalities in reverse */
     };
 
-    uint16_t bytearray_length;       /* used when search for an array of bytes or text, I guess uint16_t is enough */
-    uint16_t string_length;          /* used when search for a string */
+    uint16_t bytearray_length;       /* used when searching for an array of bytes or text, I guess uint16_t is enough */
+    uint16_t string_length;          /* used when searching for a string */
 } match_flags;
 
-/* this struct describing values retrieved from target memory */
+/* this struct describes values retrieved from target memory */
 typedef struct {
     union {
         int8_t int8_value;
@@ -80,7 +80,7 @@ typedef struct{
     int8_t is_wildcard;
 } bytearray_element_t;
 
-/* this struct describing values provided by users */
+/* this struct describes values provided by users */
 typedef struct {
     int8_t int8_value;
     uint8_t uint8_value;
@@ -99,8 +99,8 @@ typedef struct {
     match_flags flags;
 } uservalue_t;
 
-/* used when output values to user */
-/* only work for numbers */
+/* used when outputting values to user */
+/* only works for numbers */
 void valtostr(const value_t *val, char *str, size_t n);
 bool parse_uservalue_bytearray(char **argv, unsigned argc, bytearray_element_t *array, uservalue_t * val); /* parse bytearray, the parameter array should be allocated beforehand */
 bool parse_uservalue_number(const char *nptr, uservalue_t * val); /* parse int or float */
@@ -177,7 +177,7 @@ static inline void truncval_to_flags(value_t *dst, match_flags flags)
     dst->flags.s8b  &= flags.s8b;
 
     /* Hack - simply overwrite the inequality flags (this should
-       have no effect except to make them display properly) */
+       have no effect besides making them display properly) */
     dst->flags.ineq_forwards = flags.ineq_forwards;
     dst->flags.ineq_reverse  = flags.ineq_reverse;
 }


### PR DESCRIPTION
I've also changed single sentence comments to the seemingly more consistent lowercase style. American-style form has been used over British form (which I believe @sriemer said was preferred). I adjusted certain sentences slightly to make them clearer. These may need to be looked at to ensure I didn't alter a subtle meaning somewhere.