### PR TITLE
libscanmem: implement multiple match deletions

### DIFF
--- a/handlers.h
+++ b/handlers.h
@@ -74,16 +74,24 @@ bool handler__set(globals_t *vars, char **argv, unsigned argc);
 
 bool handler__list(globals_t *vars, char **argv, unsigned argc);
 
-#define DELETE_SHRTDOC "delete a known match by match-id"
-#define DELETE_LONGDOC "usage: delete match-id\n" \
-                "Remove the match `match-id` from the match list. The `match-id` can\n" \
+#define DELETE_SHRTDOC "delete known matches by match-id"
+#define DELETE_LONGDOC "usage: delete <match-id set>\n" \
+                "Remove a set of match-id's from the match list. The set format\n" \
+                "is described below. The list of match-id's can\n" \
                 "be found using the `list` command. To delete all matches, see\n" \
                 "the `reset` command.\n" \
                 "To delete all matches associated with a particular library, see the\n" \
-                "`dregion` command, which will also remove any associated matches.\n" \
-                "Example:\n" \
-                "\tdelete 0 - delete match 0\n" \
-                "NOTE: match-ids may be recalculated after matches are removed or added."
+                "`dregion` command, which will also remove any associated matches.\n\n" \
+                "The Set Format:\n" \
+                "[..a](,b..c | d, ...)[e..]\n" \
+                "The beginning and end of the set may include an optional \"open-ended\" range -\n" \
+                "`..a` means a range starting at match-id `0` to match-id `a`. `e..` means a range starting at\n" \
+                "match-id `e` to the last match-id. The rest is the same as the standard format.\n\n" \
+                "Examples:\n" \
+                "\tdelete ..5,10..15 - delete matches 0 through 5 and 10 through 15\n" \
+                "\tdelete ..5,14,20.. - delete matches 0 through 5, 14, and 20 through the last match\n\n" \
+                "NOTE: Match-ids may be recalculated after matches are removed or added. However, the set\n" \
+                "      of matches is guaranteed to be deleted properly."
 
 bool handler__delete(globals_t *vars, char **argv, unsigned argc);
 
@@ -112,6 +120,7 @@ bool handler__pid(globals_t *vars, char **argv, unsigned argc);
                 "NOTE: This can use a lot of memory with large processes."
 
 bool handler__snapshot(globals_t *vars, char **argv, unsigned argc);
+
 
 #define DREGION_SHRTDOC "delete a known region by region-id"
 #define DREGION_LONGDOC "usage: dregion [!]region-id[,region-id[,...]]\n" \

--- a/targetmem.c
+++ b/targetmem.c
@@ -123,6 +123,40 @@ void data_to_bytearray_text (char *buf, int buf_length,
     }
 }
 
+unsigned
+last_match_id (matches_and_old_values_array *matches)
+{
+    unsigned i = 0;
+
+    matches_and_old_values_swath *reading_swath_index =
+        (matches_and_old_values_swath *)matches->swaths;
+
+    int reading_iterator = 0;
+
+    if (!matches)
+        return 0;
+
+    while (reading_swath_index->first_byte_in_child) {
+        /* Only actual matches are considered */
+        if (flags_to_max_width_in_bytes(
+                reading_swath_index->data[reading_iterator].match_info) > 0)
+
+            ++i;
+
+        /* Go on to the next one... */
+        ++reading_iterator;
+        if (reading_iterator >= reading_swath_index->number_of_bytes) {
+            reading_swath_index =
+                local_address_beyond_last_element(
+                    (matches_and_old_values_swath *)reading_swath_index);
+
+            reading_iterator = 0;
+        }
+    }
+
+    return i-1;
+}
+
 match_location
 nth_match (matches_and_old_values_array *matches, unsigned n)
 {

--- a/targetmem.h
+++ b/targetmem.h
@@ -127,6 +127,8 @@ void data_to_bytearray_text (char *buf, int buf_length,
                              matches_and_old_values_swath *swath,
                              long index, int bytearray_length);
 
+unsigned last_match_id (matches_and_old_values_array *matches);
+
 match_location nth_match (matches_and_old_values_array *matches, unsigned n);
 
 matches_and_old_values_array *delete_by_region (matches_and_old_values_array *array,

--- a/value.h
+++ b/value.h
@@ -93,6 +93,19 @@ typedef struct {
     float float32_value;
     double float64_value;
 
+    void *value_set;
+    /* set properties */
+    struct {
+        size_t sz;  /* size of set (used) */
+        struct {
+            bool one_to;    /* {1 .. n}   range  */
+            bool to_end;    /* {n .. end} range} */
+            /* n value */
+            void *one_to_val;
+            void *to_end_val;
+        } n; /* special ranges */
+    } set_prop;
+
     bytearray_element_t *bytearray_value;
     const char *string_value;
 
@@ -105,6 +118,7 @@ void valtostr(const value_t *val, char *str, size_t n);
 bool parse_uservalue_bytearray(char **argv, unsigned argc, bytearray_element_t *array, uservalue_t * val); /* parse bytearray, the parameter array should be allocated beforehand */
 bool parse_uservalue_number(const char *nptr, uservalue_t * val); /* parse int or float */
 bool parse_uservalue_int(const char *nptr, uservalue_t * val);
+bool parse_uservalue_uintset(const char *, uservalue_t *);
 bool parse_uservalue_float(const char *nptr, uservalue_t * val);
 void valcpy(value_t * dst, const value_t * src);
 void uservalue2value(value_t * dst, const uservalue_t * src); /* dst.flags must be set beforehand */


### PR DESCRIPTION
value.[ch]:
* Added a routine to parse unsigned integer sets.

targetmem.[ch]:
* Added a routine to get the last match id of the current matches.
  This is needed for the "open-ended" range `n..`.

handlers.[ch]:
* Implement support for the new set.
* Updated the `delete` documentation to reflect the changes introduced
  by this commit.