### PR TITLE
Variable length types scan speedup

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -1260,7 +1260,7 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
         /* check if the new value is different */
         match_flags tmpflags;
         zero_match_flags(&tmpflags);
-        scan_routine_t valuecmp_routine = (sm_get_scanroutine(ANYNUMBER, MATCHCHANGED));
+        scan_routine_t valuecmp_routine = (sm_get_scanroutine(ANYNUMBER, MATCHCHANGED, NULL));
         if (valuecmp_routine(&o, &n, NULL, &tmpflags, address)) {
 
             valcpy(&o, &n);

--- a/ptrace.c
+++ b/ptrace.c
@@ -288,7 +288,7 @@ bool sm_checkmatches(globals_t *vars,
     size_t bytes_at_next_sample;
     size_t bytes_per_sample;
 
-    if (sm_choose_scanroutine(vars->options.scan_data_type, match_type) == false)
+    if (sm_choose_scanroutine(vars->options.scan_data_type, match_type, &uservalue->flags) == false)
     {
         show_error("unsupported scan for current data type.\n");
         return false;
@@ -463,7 +463,7 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
     match_flags zero_flag;
     zero_match_flags(&zero_flag);
     
-    if (sm_choose_scanroutine(vars->options.scan_data_type, match_type) == false)
+    if (sm_choose_scanroutine(vars->options.scan_data_type, match_type, &uservalue->flags) == false)
     {
         show_error("unsupported scan for current data type.\n"); 
         return false;

--- a/scanroutines.c
+++ b/scanroutines.c
@@ -295,6 +295,8 @@ extern inline int scan_routine_STRING_ANY SCAN_ROUTINE_ARGUMENTS
 {
    return saveflags->length = ((old_value)->flags.length);
 }
+
+/* Used only for length>8 */
 extern inline int scan_routine_STRING_EQUALTO SCAN_ROUTINE_ARGUMENTS
 {
     const char *scan_string = user_value->string_value;
@@ -357,6 +359,34 @@ DEFINE_STRING_POW2_EQUALTO_ROUTINE(8)
 DEFINE_STRING_POW2_EQUALTO_ROUTINE(16)
 DEFINE_STRING_POW2_EQUALTO_ROUTINE(32)
 DEFINE_STRING_POW2_EQUALTO_ROUTINE(64)
+
+#define DEFINE_STRING_SMALLOOP_EQUALTO_ROUTINE(WIDTH) \
+    extern inline int scan_routine_STRING##WIDTH##_EQUALTO SCAN_ROUTINE_ARGUMENTS \
+    { \
+        if (!new_value->flags.length) \
+        { \
+            /* new_value is not actually a valid string */ \
+            return 0; \
+        } \
+        const char *scan_string = user_value->string_value; \
+        int i; \
+        for(i = 0; i < (WIDTH)/8; ++i) \
+        { \
+            if(new_value->chars[i] != scan_string[i]) \
+            { \
+                /* not matched */ \
+                return 0; \
+            } \
+        } \
+        /* matched */ \
+        saveflags->length = (WIDTH)/8; \
+        return (WIDTH)/8; \
+    }
+
+DEFINE_STRING_SMALLOOP_EQUALTO_ROUTINE(24)
+DEFINE_STRING_SMALLOOP_EQUALTO_ROUTINE(40)
+DEFINE_STRING_SMALLOOP_EQUALTO_ROUTINE(48)
+DEFINE_STRING_SMALLOOP_EQUALTO_ROUTINE(56)
 
 /*-------------------------*/
 /* Any-xxx types specifiec */
@@ -437,8 +467,20 @@ DEFINE_ANYTYPE_ROUTINE(RANGE)
             case 2: \
                 return &scan_routine_STRING16_##ROUTINEMATCHTYPENAME; \
                 break; \
+            case 3: \
+                return &scan_routine_STRING24_##ROUTINEMATCHTYPENAME; \
+                break; \
             case 4: \
                 return &scan_routine_STRING32_##ROUTINEMATCHTYPENAME; \
+                break; \
+            case 5: \
+                return &scan_routine_STRING40_##ROUTINEMATCHTYPENAME; \
+                break; \
+            case 6: \
+                return &scan_routine_STRING48_##ROUTINEMATCHTYPENAME; \
+                break; \
+            case 7: \
+                return &scan_routine_STRING56_##ROUTINEMATCHTYPENAME; \
                 break; \
             case 8: \
                 return &scan_routine_STRING64_##ROUTINEMATCHTYPENAME; \

--- a/scanroutines.c
+++ b/scanroutines.c
@@ -279,7 +279,8 @@ extern inline int scan_routine_VLT_ANY SCAN_ROUTINE_ARGUMENTS
 /*---------------*/
 extern inline int scan_routine_BYTEARRAY_EQUALTO SCAN_ROUTINE_ARGUMENTS
 {
-    const bytearray_element_t *array = user_value->bytearray_value;
+    const uint8_t *bytes_array = user_value->bytearray_value;
+    const wildcard_t *wildcards_array = user_value->wildcard_value;
     int length = user_value->flags.length;
     int cur_idx = 0;
     int i, j;
@@ -289,8 +290,7 @@ extern inline int scan_routine_BYTEARRAY_EQUALTO SCAN_ROUTINE_ARGUMENTS
         /* match current block */
         for(j = 0; j < sizeof(int64_t); ++j)
         {
-            if(     (array[cur_idx].is_wildcard == 1) 
-                 || (array[cur_idx].byte == val_buf.bytes[j])) 
+            if (bytes_array[cur_idx] == (val_buf.bytes[j] & wildcards_array[cur_idx]))
             {
                 /* pass */
             }
@@ -313,8 +313,7 @@ extern inline int scan_routine_BYTEARRAY_EQUALTO SCAN_ROUTINE_ARGUMENTS
     /* match bytes left */
     for(j = 0; j < length - i; ++j)
     {
-        if(     (array[cur_idx].is_wildcard == 1) 
-             || (array[cur_idx].byte == val_buf.bytes[j])) 
+        if (bytes_array[cur_idx] == (val_buf.bytes[j] & wildcards_array[cur_idx]))
         {
             /* pass */
         }

--- a/scanroutines.c
+++ b/scanroutines.c
@@ -225,6 +225,47 @@ DEFINE_INTEGER_RANGE_ROUTINE(INTEGER64, 64)
 DEFINE_FLOAT_RANGE_ROUTINE(FLOAT32, 32)
 DEFINE_FLOAT_RANGE_ROUTINE(FLOAT64, 64)
 
+/*-------------------------*/
+/* Any-xxx types specifiec */
+/*-------------------------*/
+/* this is for anynumber, anyinteger, anyfloat */
+#define DEFINE_ANYTYPE_ROUTINE(MATCHTYPENAME) \
+    extern inline int scan_routine_ANYINTEGER_##MATCHTYPENAME SCAN_ROUTINE_ARGUMENTS \
+    { \
+        int ret = 0, tmp_ret;\
+        if ((tmp_ret = scan_routine_INTEGER8_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
+        if ((tmp_ret = scan_routine_INTEGER16_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
+        if ((tmp_ret = scan_routine_INTEGER32_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
+        if ((tmp_ret = scan_routine_INTEGER64_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
+        return ret; \
+    } \
+    extern inline int scan_routine_ANYFLOAT_##MATCHTYPENAME SCAN_ROUTINE_ARGUMENTS \
+    { \
+        int ret = 0, tmp_ret; \
+        if ((tmp_ret = scan_routine_FLOAT32_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
+        if ((tmp_ret = scan_routine_FLOAT64_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
+        return ret; \
+    } \
+    extern inline int scan_routine_ANYNUMBER_##MATCHTYPENAME SCAN_ROUTINE_ARGUMENTS \
+    { \
+        int ret1 = scan_routine_ANYINTEGER_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address); \
+        int ret2 = scan_routine_ANYFLOAT_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address); \
+        return (ret1 > ret2 ? ret1 : ret2); \
+    } \
+
+DEFINE_ANYTYPE_ROUTINE(ANY)
+DEFINE_ANYTYPE_ROUTINE(EQUALTO)
+DEFINE_ANYTYPE_ROUTINE(NOTEQUALTO)
+DEFINE_ANYTYPE_ROUTINE(CHANGED)
+DEFINE_ANYTYPE_ROUTINE(NOTCHANGED)
+DEFINE_ANYTYPE_ROUTINE(INCREASED)
+DEFINE_ANYTYPE_ROUTINE(DECREASED)
+DEFINE_ANYTYPE_ROUTINE(GREATERTHAN)
+DEFINE_ANYTYPE_ROUTINE(LESSTHAN)
+DEFINE_ANYTYPE_ROUTINE(INCREASEDBY)
+DEFINE_ANYTYPE_ROUTINE(DECREASEDBY)
+DEFINE_ANYTYPE_ROUTINE(RANGE)
+
 /*----------------------------------------*/
 /* for generic VLT (Variable Length Type) */
 /*----------------------------------------*/
@@ -404,52 +445,10 @@ DEFINE_STRING_SMALLOOP_EQUALTO_ROUTINE(40)
 DEFINE_STRING_SMALLOOP_EQUALTO_ROUTINE(48)
 DEFINE_STRING_SMALLOOP_EQUALTO_ROUTINE(56)
 
-/*-------------------------*/
-/* Any-xxx types specifiec */
-/*-------------------------*/
-/* this is for anynumber, anyinteger and anyfloat */
-#define DEFINE_ANYTYPE_ROUTINE(MATCHTYPENAME) \
-    extern inline int scan_routine_ANYINTEGER_##MATCHTYPENAME SCAN_ROUTINE_ARGUMENTS \
-    { \
-        int ret = 0, tmp_ret;\
-        if ((tmp_ret = scan_routine_INTEGER8_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
-        if ((tmp_ret = scan_routine_INTEGER16_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
-        if ((tmp_ret = scan_routine_INTEGER32_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
-        if ((tmp_ret = scan_routine_INTEGER64_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
-        return ret; \
-    } \
-    extern inline int scan_routine_ANYFLOAT_##MATCHTYPENAME SCAN_ROUTINE_ARGUMENTS \
-    { \
-        int ret = 0, tmp_ret; \
-        if ((tmp_ret = scan_routine_FLOAT32_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
-        if ((tmp_ret = scan_routine_FLOAT64_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address)) > ret) { ret = tmp_ret; } \
-        return ret; \
-    } \
-    extern inline int scan_routine_ANYNUMBER_##MATCHTYPENAME SCAN_ROUTINE_ARGUMENTS \
-    { \
-        int ret1 = scan_routine_ANYINTEGER_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address); \
-        int ret2 = scan_routine_ANYFLOAT_##MATCHTYPENAME (new_value, old_value, user_value, saveflags, address); \
-        return (ret1 > ret2 ? ret1 : ret2); \
-    } \
-
-DEFINE_ANYTYPE_ROUTINE(ANY)
-DEFINE_ANYTYPE_ROUTINE(EQUALTO)
-DEFINE_ANYTYPE_ROUTINE(NOTEQUALTO)
-DEFINE_ANYTYPE_ROUTINE(CHANGED)
-DEFINE_ANYTYPE_ROUTINE(NOTCHANGED)
-DEFINE_ANYTYPE_ROUTINE(INCREASED)
-DEFINE_ANYTYPE_ROUTINE(DECREASED)
-DEFINE_ANYTYPE_ROUTINE(GREATERTHAN)
-DEFINE_ANYTYPE_ROUTINE(LESSTHAN)
-DEFINE_ANYTYPE_ROUTINE(INCREASEDBY)
-DEFINE_ANYTYPE_ROUTINE(DECREASEDBY)
-DEFINE_ANYTYPE_ROUTINE(RANGE)
-
 
 /***************************************************************/
 /* choose a routine according to scan_data_type and match_type */
 /***************************************************************/
-
 
 
 #define CHOOSE_ROUTINE(SCANDATATYPE, ROUTINEDATATYPENAME, SCANMATCHTYPE, ROUTINEMATCHTYPENAME) \
@@ -468,6 +467,7 @@ DEFINE_ANYTYPE_ROUTINE(RANGE)
     CHOOSE_ROUTINE(ANYINTEGER, ANYINTEGER, SCANMATCHTYPE, ROUTINEMATCHTYPENAME) \
     CHOOSE_ROUTINE(ANYFLOAT, ANYFLOAT, SCANMATCHTYPE, ROUTINEMATCHTYPENAME) \
     CHOOSE_ROUTINE(ANYNUMBER, ANYNUMBER, SCANMATCHTYPE, ROUTINEMATCHTYPENAME) \
+
 
 #define SELECTION_CASE(ROUTINEDATATYPENAME, WIDTH, ROUTINEMATCHTYPENAME) \
     case (WIDTH): \
@@ -497,11 +497,6 @@ DEFINE_ANYTYPE_ROUTINE(RANGE)
     }
 
 
-bool sm_choose_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const match_flags* uflags)
-{
-    return (sm_scan_routine = sm_get_scanroutine(dt, mt, uflags)) != NULL;
-}
-
 scan_routine_t sm_get_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const match_flags* uflags)
 {
     CHOOSE_ROUTINE_FOR_ALL_NUMBER_TYPES(MATCHANY, ANY)
@@ -524,4 +519,10 @@ scan_routine_t sm_get_scanroutine(scan_data_type_t dt, scan_match_type_t mt, con
     }
 
     return NULL;
+}
+
+
+bool sm_choose_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const match_flags* uflags)
+{
+    return (sm_scan_routine = sm_get_scanroutine(dt, mt, uflags)) != NULL;
 }

--- a/scanroutines.h
+++ b/scanroutines.h
@@ -71,8 +71,8 @@ extern scan_routine_t sm_scan_routine;
  * Choose the global scanroutine according to the given parameters, sm_scan_routine will be set.
  * Returns whether a proper routine has been found.
  */
-bool sm_choose_scanroutine(scan_data_type_t dt, scan_match_type_t mt);
+bool sm_choose_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const match_flags* uflags);
 
-scan_routine_t sm_get_scanroutine(scan_data_type_t dt, scan_match_type_t mt);
+scan_routine_t sm_get_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const match_flags* uflags);
 
 #endif /* SCANROUTINES_H */

--- a/value.h
+++ b/value.h
@@ -175,22 +175,15 @@ static inline void truncval(value_t *dst, const value_t *src)
     truncval_to_flags(dst, src->flags);
 }
 
-/* set all possible width flags, if nothing is known about val */
+/* set all possible width flags, if nothing is known about val
+ * when scanning for a VLT, this will set the length to the uint16
+ * maximum value, in line with the 'maximum width' idea */
 static inline void valnowidth(value_t *val)
 {
     assert(val);
 
-    val->flags.u64b = 1;
-    val->flags.s64b = 1;
-    val->flags.u32b = 1;
-    val->flags.s32b = 1;
-    val->flags.u16b = 1;
-    val->flags.s16b = 1;
-    val->flags.u8b  = 1;
-    val->flags.s8b  = 1;
-    val->flags.f64b = 1;
-    val->flags.f32b = 1;
-
+    /* set all flags to 1 in a single go */
+    val->flags.all_flags = 0xffffU;
     return;
 }
 

--- a/value.h
+++ b/value.h
@@ -68,6 +68,7 @@ typedef struct {
         float float32_value;
         double float64_value;
         uint8_t bytes[sizeof(int64_t)];
+        char chars[sizeof(int64_t)];
     };
     
     match_flags flags;


### PR DESCRIPTION
I'm pulling in a rework of the variable length types (VLT for short) scan functions, salient points:

* Implement basic incoming memory length-checking, which offers a bit more safety and fixes the VLT returning from deletion of #204 .
* Massively optimize both small lengths (time -60%) and immediately not matching big lengths (-50%)'s scan time
* Rework bytearray wildcards, for another 15% speedup stacked on
* Finally closes #226 , as now VLT length is fully exploited

This PR features a fair share of type punning via pointer casting, I'm 99.9% sure that I've not introduced unaligned access on ARM, because the pointers I recast and dereference have enough alignment anyway, but I'd appreciate if someone could check on ARM.