### PR TITLE
Api simplification

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,6 @@ libscanmem_la_include_HEADERS = commands.h \
 
 libscanmem_la_SOURCES = commands.c \
     ptrace.c \
-    menu.c \
     handlers.h \
     handlers.c \
     interrupt.h \
@@ -48,7 +47,10 @@ libscanmem_la_LDFLAGS = -version-info 1:0:0
 
 bin_PROGRAMS = scanmem
 
-scanmem_SOURCES = main.c
+scanmem_SOURCES = menu.h \
+    menu.c \
+    main.c
+
 scanmem_LDADD = libscanmem.la
 
 dist_man_MANS = scanmem.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,11 +38,6 @@ if !HAVE_GETLINE
       getline.c
 endif
 
-if !WITH_READLINE
-  libscanmem_la_SOURCES += readline.h \
-      readline.c
-endif
-
 libscanmem_la_LDFLAGS = -version-info 1:0:0
 
 bin_PROGRAMS = scanmem
@@ -50,6 +45,11 @@ bin_PROGRAMS = scanmem
 scanmem_SOURCES = menu.h \
     menu.c \
     main.c
+
+if !WITH_READLINE
+  scanmem_SOURCES += readline.h \
+      readline.c
+endif
 
 scanmem_LDADD = libscanmem.la
 

--- a/main.c
+++ b/main.c
@@ -39,6 +39,8 @@
 #include "commands.h"
 #include "show_message.h"
 
+#include "menu.h"
+
 
 static const char copy_text[] =
 "Copyright (C) 2006-2009 Tavis Ormandy\n"
@@ -179,7 +181,7 @@ int main(int argc, char **argv)
         char *line;
 
         /* reads in a commandline from the user and returns a pointer to it in *line */
-        if (sm_getcommand(vars, &line) == false) {
+        if (getcommand(vars, &line) == false) {
             show_error("failed to read in a command.\n");
             ret = EXIT_FAILURE;
             break;

--- a/menu.c
+++ b/menu.c
@@ -124,28 +124,12 @@ bool sm_getcommand(globals_t *vars, char **line)
     rl_attempted_completion_function = commandcompletion;
 
     while (true) {
-        if (vars->options.backend == 0)
-        {
-            /* for normal users, read in the next command using readline library */
-            success = ((*line = readline(prompt)) != NULL);
-        }
-        else 
-        {
-            /* disable readline for front-end, since readline may produce ansi escape codes, which is terrible for front-end */
-            printf("%s\n", prompt); /* add a newline for front-end */
-            fflush(stdout); /* otherwise front-end may not receive this */
-            *line = NULL; /* let getline malloc it */
-            size_t n;
-            ssize_t bytes_read = getline(line, &n, stdin);
-            success = (bytes_read > 0);
-            if (success)
-                (*line)[bytes_read-1] = '\0'; /* remove the trailing newline */
-        }
+
+        success = ((*line = readline(prompt)) != NULL);
         if (!success) {
             /* EOF */
             if ((*line = strdup("__eof")) == NULL) {
-                fprintf(stderr,
-                        "error: sorry, there was a memory allocation error.\n");
+                show_error("sorry, there was a memory allocation error.\n");
                 return false;
             }
         }

--- a/menu.c
+++ b/menu.c
@@ -1,23 +1,23 @@
 /*
-    Prompt, command completion and version information.
+    Prompt and command completion.
 
     Copyright (C) 2006,2007,2009 Tavis Ormandy <taviso@sdf.lonestar.org>
     Copyright (C) 2010,2011 Lu Wang <coolwanglu@gmail.com>
 
-    This file is part of libscanmem.
+    This file is part of scanmem.
 
-    This library is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 3 of the License, or
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    This library is distributed in the hope that it will be useful,
+    This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+    GNU General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with this library.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef _GNU_SOURCE
@@ -40,6 +40,7 @@
 #include "readline.h"
 #endif
 
+#include "menu.h"
 #include "getline.h"
 #include "scanmem.h"
 #include "commands.h"
@@ -102,12 +103,12 @@ static char **commandcompletion(const char *text, int start, int end)
 
 
 /*
- * sm_getcommand() reads in a command using readline and places a pointer to
+ * getcommand() reads in a command using readline and places a pointer to
  * the read string into *line, which must be free'd by caller.
  * returns true on success, or false on error.
  */
 
-bool sm_getcommand(globals_t *vars, char **line)
+bool getcommand(globals_t *vars, char **line)
 {
     char prompt[64];
     bool success = true;

--- a/menu.h
+++ b/menu.h
@@ -1,0 +1,36 @@
+/*
+    Prompt and command completion.
+
+    Copyright (C) 2017 Andrea Stacchiotti  <andreastacchiotti(a)gmail.com>
+
+    This file is part of scanmem.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MENU_H
+#define MENU_H
+
+#include <stdbool.h>
+
+#include "scanmem.h"
+
+/*
+ * getcommand() reads in a command using readline, and places a pointer to
+ * the read string into *line, _which must be free'd by caller_.
+ * returns true on success, or false on error.
+ */
+bool getcommand(globals_t *vars, char **line);
+
+#endif /* MENU_H */

--- a/scanmem.h
+++ b/scanmem.h
@@ -64,10 +64,6 @@
     })
 #endif
 
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif
-
 /* global settings */
 typedef struct {
     unsigned exit:1;

--- a/scanmem.h
+++ b/scanmem.h
@@ -115,7 +115,4 @@ bool sm_attach(pid_t target);
 bool sm_read_array(pid_t target, const void *addr, char *buf, int len);
 bool sm_write_array(pid_t target, void *addr, const void *data, int len);
 
-/* menu.c */
-bool sm_getcommand(globals_t *vars, char **line);
-
 #endif /* SCANMEM_H */


### PR DESCRIPTION
Some light restructuring to better separate libscanmem from scanmem (see #186 ).

I'm not sure what the best practices to present an interface are, but I'm trying to move away from `scanmem.h` as "it is included by everything and defines all the random things"

There's not much to review, just ensure I haven't borked the build in some edge case.