### PR TITLE
Full libscanmem separation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,8 @@ if !HAVE_GETLINE
       getline.c
 endif
 
-libscanmem_la_LDFLAGS = -version-info 1:0:0
+libscanmem_la_LDFLAGS = -version-info 1:0:0 \
+                        -export-symbols-regex '^sm_|^show_'
 
 bin_PROGRAMS = scanmem
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,7 +21,6 @@ libscanmem_la_include_HEADERS = commands.h \
 
 libscanmem_la_SOURCES = commands.c \
     ptrace.c \
-    menu.c \
     handlers.h \
     handlers.c \
     interrupt.h \
@@ -48,7 +47,10 @@ libscanmem_la_LDFLAGS = -version-info 1:0:0
 
 bin_PROGRAMS = scanmem
 
-scanmem_SOURCES = main.c
+scanmem_SOURCES = menu.h \
+    menu.c \
+    main.c
+
 scanmem_LDADD = libscanmem.la
 
 dist_man_MANS = scanmem.1

--- a/Makefile.am
+++ b/Makefile.am
@@ -38,11 +38,6 @@ if !HAVE_GETLINE
       getline.c
 endif
 
-if !WITH_READLINE
-  libscanmem_la_SOURCES += readline.h \
-      readline.c
-endif
-
 libscanmem_la_LDFLAGS = -version-info 1:0:0
 
 bin_PROGRAMS = scanmem
@@ -50,6 +45,11 @@ bin_PROGRAMS = scanmem
 scanmem_SOURCES = menu.h \
     menu.c \
     main.c
+
+if !WITH_READLINE
+  scanmem_SOURCES += readline.h \
+      readline.c
+endif
 
 scanmem_LDADD = libscanmem.la
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,7 @@ libscanmem_la_include_HEADERS = commands.h \
     value.h
 
 libscanmem_la_SOURCES = commands.c \
+    common.h \
     ptrace.c \
     handlers.h \
     handlers.c \

--- a/commands.c
+++ b/commands.c
@@ -37,6 +37,7 @@
 #include <ctype.h>
 
 #include "commands.h"
+#include "common.h"
 #include "show_message.h"
 
 /*

--- a/common.h
+++ b/common.h
@@ -1,0 +1,55 @@
+/*
+    Common macro and helpers.
+
+    Copyright (C) 2017 Andrea Stacchiotti  <andreastacchiotti(a)gmail.com>
+
+    This file is part of libscanmem.
+
+    This library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#ifndef MIN
+# define MIN(a,b) ((a) < (b) ? (a) : (b))
+#endif
+
+/* from string.h in glibc for Android/BSD */
+#ifndef strdupa
+# include <alloca.h>
+# include <string.h>
+# define strdupa(s)                                                           \
+    ({                                                                        \
+      const char *__old = (s);                                                \
+      size_t __len = strlen(__old) + 1;                                       \
+      char *__new = (char *) alloca(__len);                                   \
+      (char *) memcpy(__new, __old, __len);                                   \
+    })
+#endif
+
+#ifndef strndupa
+# include <alloca.h>
+# include <string.h>
+# define strndupa(s, n)                                                       \
+    ({                                                                        \
+      const char *__old = (s);                                                \
+      size_t __len = strnlen(__old, (n));                                     \
+      char *__new = (char *) alloca(__len + 1);                               \
+      __new[__len] = '\0';                                                    \
+      (char *) memcpy(__new, __old, __len);                                   \
+    })
+#endif
+
+#endif /* COMMON_H */

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -1171,6 +1171,7 @@ class GameConqueror():
 
     def exit(self, object, data=None):
         self.exit_flag = True
+        self.backend.exit_cleanup()
         Gtk.main_quit()
 
     def check_backend_version(self):

--- a/gui/backend.py
+++ b/gui/backend.py
@@ -27,6 +27,7 @@ import misc
 class GameConquerorBackend():
     BACKEND_FUNCS = {
         'sm_init' : (ctypes.c_bool, ),
+        'sm_cleanup' : (None, ),
         'sm_set_backend' : (None, ),
         'sm_backend_exec_cmd' : (None, ctypes.c_char_p),
         'sm_get_num_matches' : (ctypes.c_ulong, ),
@@ -77,3 +78,6 @@ class GameConquerorBackend():
 
     def set_stop_flag(self, stop_flag):
         self.lib.sm_set_stop_flag(stop_flag)
+
+    def exit_cleanup(self):
+        self.lib.sm_cleanup()

--- a/handlers.c
+++ b/handlers.c
@@ -47,6 +47,7 @@
 #include <inttypes.h>
 #include <ctype.h>
 
+#include "common.h"
 #include "commands.h"
 #include "endianness.h"
 #include "handlers.h"

--- a/main.c
+++ b/main.c
@@ -204,13 +204,6 @@ int main(int argc, char **argv)
     }
 
 end:
-
-    /* now free any allocated memory used */
-    l_destroy(vars->regions);
-    l_destroy(vars->commands);
-
-    /* attempt to detach just in case */
-    (void) sm_detach(vars->target);
-
+    sm_cleanup();
     return ret;
 }

--- a/main.c
+++ b/main.c
@@ -39,6 +39,8 @@
 #include "commands.h"
 #include "show_message.h"
 
+#include "menu.h"
+
 
 static const char copy_text[] =
 "Copyright (C) 2006-2009 Tavis Ormandy\n"
@@ -179,7 +181,7 @@ int main(int argc, char **argv)
         char *line;
 
         /* reads in a commandline from the user and returns a pointer to it in *line */
-        if (sm_getcommand(vars, &line) == false) {
+        if (getcommand(vars, &line) == false) {
             show_error("failed to read in a command.\n");
             ret = EXIT_FAILURE;
             break;

--- a/menu.c
+++ b/menu.c
@@ -124,28 +124,12 @@ bool sm_getcommand(globals_t *vars, char **line)
     rl_attempted_completion_function = commandcompletion;
 
     while (true) {
-        if (vars->options.backend == 0)
-        {
-            /* for normal users, read in the next command using readline library */
-            success = ((*line = readline(prompt)) != NULL);
-        }
-        else 
-        {
-            /* disable readline for front-end, since readline may produce ansi escape codes, which is terrible for front-end */
-            printf("%s\n", prompt); /* add a newline for front-end */
-            fflush(stdout); /* otherwise front-end may not receive this */
-            *line = NULL; /* let getline malloc it */
-            size_t n;
-            ssize_t bytes_read = getline(line, &n, stdin);
-            success = (bytes_read > 0);
-            if (success)
-                (*line)[bytes_read-1] = '\0'; /* remove the trailing newline */
-        }
+
+        success = ((*line = readline(prompt)) != NULL);
         if (!success) {
             /* EOF */
             if ((*line = strdup("__eof")) == NULL) {
-                fprintf(stderr,
-                        "error: sorry, there was a memory allocation error.\n");
+                show_error("sorry, there was a memory allocation error.\n");
                 return false;
             }
         }

--- a/menu.c
+++ b/menu.c
@@ -1,23 +1,23 @@
 /*
-    Prompt, command completion and version information.
+    Prompt and command completion.
 
     Copyright (C) 2006,2007,2009 Tavis Ormandy <taviso@sdf.lonestar.org>
     Copyright (C) 2010,2011 Lu Wang <coolwanglu@gmail.com>
 
-    This file is part of libscanmem.
+    This file is part of scanmem.
 
-    This library is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Lesser General Public License as published
-    by the Free Software Foundation; either version 3 of the License, or
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    This library is distributed in the hope that it will be useful,
+    This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Lesser General Public License for more details.
+    GNU General Public License for more details.
 
-    You should have received a copy of the GNU Lesser General Public License
-    along with this library.  If not, see <http://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef _GNU_SOURCE
@@ -40,6 +40,7 @@
 #include "readline.h"
 #endif
 
+#include "menu.h"
 #include "getline.h"
 #include "scanmem.h"
 #include "commands.h"
@@ -102,12 +103,12 @@ static char **commandcompletion(const char *text, int start, int end)
 
 
 /*
- * sm_getcommand() reads in a command using readline and places a pointer to
+ * getcommand() reads in a command using readline and places a pointer to
  * the read string into *line, which must be free'd by caller.
  * returns true on success, or false on error.
  */
 
-bool sm_getcommand(globals_t *vars, char **line)
+bool getcommand(globals_t *vars, char **line)
 {
     char prompt[64];
     bool success = true;

--- a/menu.h
+++ b/menu.h
@@ -1,0 +1,36 @@
+/*
+    Prompt and command completion.
+
+    Copyright (C) 2017 Andrea Stacchiotti  <andreastacchiotti(a)gmail.com>
+
+    This file is part of scanmem.
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef MENU_H
+#define MENU_H
+
+#include <stdbool.h>
+
+#include "scanmem.h"
+
+/*
+ * getcommand() reads in a command using readline, and places a pointer to
+ * the read string into *line, _which must be free'd by caller_.
+ * returns true on success, or false on error.
+ */
+bool getcommand(globals_t *vars, char **line);
+
+#endif /* MENU_H */

--- a/scanmem.c
+++ b/scanmem.c
@@ -188,6 +188,16 @@ bool sm_init(void)
     return true;
 }
 
+void sm_cleanup(void)
+{
+    /* free any allocated memory used */
+    l_destroy(sm_globals.regions);
+    l_destroy(sm_globals.commands);
+
+    /* attempt to detach just in case */
+    sm_detach(sm_globals.target);
+}
+
 /* for front-ends */
 void sm_set_backend(void)
 {

--- a/scanmem.h
+++ b/scanmem.h
@@ -119,7 +119,4 @@ bool sm_attach(pid_t target);
 bool sm_read_array(pid_t target, const void *addr, char *buf, int len);
 bool sm_write_array(pid_t target, void *addr, const void *data, int len);
 
-/* menu.c */
-bool sm_getcommand(globals_t *vars, char **line);
-
 #endif /* SCANMEM_H */

--- a/scanmem.h
+++ b/scanmem.h
@@ -27,7 +27,6 @@
 
 #include <stdio.h>
 #include <stdint.h>
-#include <string.h>
 #include <sys/types.h>
 
 #include "scanroutines.h"
@@ -35,38 +34,6 @@
 #include "value.h"
 #include "targetmem.h"
 
-
-#ifndef PACKAGE_VERSION
-#define PACKAGE_VERSION "(unknown)"
-#endif
-
-/* from string.h in glibc for Android/BSD */
-#ifndef strdupa
-# include <alloca.h>
-# define strdupa(s)                                                           \
-    ({                                                                        \
-      const char *__old = (s);                                                \
-      size_t __len = strlen(__old) + 1;                                       \
-      char *__new = (char *) alloca(__len);                                   \
-      (char *) memcpy(__new, __old, __len);                                   \
-    })
-#endif
-
-#ifndef strndupa
-# include <alloca.h>
-# define strndupa(s, n)                                                       \
-    ({                                                                        \
-      const char *__old = (s);                                                \
-      size_t __len = strnlen(__old, (n));                                     \
-      char *__new = (char *) alloca(__len + 1);                               \
-      __new[__len] = '\0';                                                    \
-      (char *) memcpy(__new, __old, __len);                                   \
-    })
-#endif
-
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif
 
 /* global settings */
 typedef struct {

--- a/scanmem.h
+++ b/scanmem.h
@@ -65,6 +65,7 @@ typedef struct {
 extern globals_t sm_globals;
 
 bool sm_init(void);
+void sm_cleanup(void);
 void sm_printversion(FILE *outfd);
 void sm_set_backend(void);
 void sm_backend_exec_cmd(const char *commandline);


### PR DESCRIPTION
Set of changes that should completely separate libscanmem from the CLI frontend, finally closing #186 .

This superseded #262 , which I closed earlier.

Highlights:

* Removed everything that's not a main `sm_*` function from `scanmem.h`
* Made both `menu.{h,c}` and `readline.{h,c}` sm dependences instead of libsm dependencies. libsm compiles without both. Complete independence of libsm from libreadline requires a bit more autotools meddling
* Expose only `sm_*` and `show_*` in the dynamic library, which seems a reasonable interface to maintain, instead of exposing basically everything
* Bring proper end-of-life cleanup to front-ends (the GUI used to hope that the OS would reclaim sm's memory at closure, now it actually calls `free()`)

The API still isn't final (that's why I didn't update the version number), as I have a last rather big change before v0.17, which changes a signature.

@sriemer , @bkazemi , please have a look, as I'm a bit outside my element here.