### PR TITLE
Incoming memory rewrite

### DIFF
--- a/endianness.h
+++ b/endianness.h
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "scanmem.h"
 #include "value.h"
 
 /* true if host is big endian */
@@ -40,6 +39,11 @@ static const bool big_endian = true;
 #else
 static const bool big_endian = false;
 #endif
+
+static inline uint8_t swap_bytes8(uint8_t i)
+{
+    return i;
+}
 
 static inline uint16_t swap_bytes16(uint16_t i)
 {
@@ -86,9 +90,9 @@ static inline void swap_bytes_var(void *p, size_t num)
     return;
 }
 
-static inline void fix_endianness(globals_t *vars, value_t *data_value)
+static inline void fix_endianness(value_t *data_value, bool reverse_endianness)
 {
-    if (!vars->options.reverse_endianness) {
+    if (!reverse_endianness) {
         return;
     }
     if (data_value->flags.u64b) {

--- a/handlers.c
+++ b/handlers.c
@@ -278,7 +278,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                 while (reading_swath_index->first_byte_in_child) {
 
                     /* only actual matches are considered */
-                    if (flags_to_max_width_in_bytes(reading_swath_index->data[reading_iterator].match_info) > 0)
+                    if (reading_swath_index->data[reading_iterator].match_info.all_flags != 0)
                     {
                         void *address = remote_address_of_nth_element(reading_swath_index, reading_iterator);
 
@@ -377,7 +377,7 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
         match_flags flags = reading_swath_index->data[reading_iterator].match_info;
 
         /* only actual matches are considered */
-        if (flags_to_max_width_in_bytes(flags) > 0)
+        if (flags.all_flags != 0)
         {
             switch(vars->options.scan_data_type)
             {

--- a/handlers.c
+++ b/handlers.c
@@ -1084,7 +1084,7 @@ bool handler__update(globals_t *vars, char **argv, unsigned argc)
 
     USEPARAMS();
     if (vars->num_matches) {
-        if (sm_checkmatches(vars, MATCHANY, NULL) == false) {
+        if (sm_checkmatches(vars, MATCHUPDATE, NULL) == false) {
             show_error("failed to scan target address space.\n");
             return false;
         }

--- a/scanmem.h
+++ b/scanmem.h
@@ -82,7 +82,7 @@ bool sm_checkmatches(globals_t *vars, scan_match_type_t match_type,
                      const uservalue_t *uservalue);
 bool sm_searchregions(globals_t *vars, scan_match_type_t match_type,
                       const uservalue_t *uservalue);
-bool sm_peekdata(pid_t pid, const void *addr, value_t *result);
+bool sm_peekdata(pid_t pid, const void *addr, uint16_t length, const mem64_t **result_ptr, size_t *memlength);
 bool sm_attach(pid_t target);
 bool sm_read_array(pid_t target, const void *addr, char *buf, int len);
 bool sm_write_array(pid_t target, void *addr, const void *data, int len);

--- a/scanroutines.h
+++ b/scanroutines.h
@@ -54,25 +54,27 @@ typedef enum {
     MATCHCHANGED,
     MATCHINCREASED,
     MATCHDECREASED,
-    /* folowing: compare with both given value and old value */
+    /* following: compare with both given value and old value */
     MATCHINCREASEDBY,
     MATCHDECREASEDBY
 } scan_match_type_t;
 
 
-/* match old_value against new_value or user_value (or both, depending on the matching type, store the result into save */
-/* NOTE: saveflag must be set to 0, since only useful bits are set, but extra bits are not cleared! */
-/*       address is pointing to new_value in TARGET PROCESS MEMORY SPACE, used when searching for a byte array */
-/* return the number of bytes needed to store old_value, 0 for not matched */
-typedef int (*scan_routine_t)(const value_t *new_value, const value_t *old_value, const uservalue_t *user_value, match_flags *saveflag, const void *address);
+/* Matches a memory area given by `memory_ptr` and `memlength` against `user_value` or `old_value`
+ * (or both, depending on the matching type), stores the result into saveflags.
+ * NOTE: saveflags must be set to 0, since only useful bits are set, but extra bits are not cleared!
+ * Returns the number of bytes needed to store said match, 0 for not matched
+ */
+typedef unsigned int (*scan_routine_t)(const mem64_t *memory_ptr, size_t memlength,
+                                       const value_t *old_value, const uservalue_t *user_value, match_flags *saveflags);
 extern scan_routine_t sm_scan_routine;
 
 /* 
  * Choose the global scanroutine according to the given parameters, sm_scan_routine will be set.
  * Returns whether a proper routine has been found.
  */
-bool sm_choose_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const uservalue_t* uval);
+bool sm_choose_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const uservalue_t* uval, bool reverse_endianness);
 
-scan_routine_t sm_get_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const match_flags* uflags);
+scan_routine_t sm_get_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const match_flags* uflags, bool reverse_endianness);
 
 #endif /* SCANROUTINES_H */

--- a/scanroutines.h
+++ b/scanroutines.h
@@ -42,14 +42,15 @@ typedef enum {
 } scan_data_type_t;
 
 typedef enum {
-    MATCHANY,                 /* to update */
+    MATCHANY,                /* for snapshot */
     /* following: compare with a given value */
     MATCHEQUALTO,
-    MATCHNOTEQUALTO,          
+    MATCHNOTEQUALTO,
     MATCHGREATERTHAN,
     MATCHLESSTHAN,
     MATCHRANGE,
     /* following: compare with the old value */
+    MATCHUPDATE,
     MATCHNOTCHANGED,
     MATCHCHANGED,
     MATCHINCREASED,

--- a/targetmem.c
+++ b/targetmem.c
@@ -134,8 +134,7 @@ nth_match (matches_and_old_values_array *matches, size_t n)
 
     while (reading_swath_index->first_byte_in_child) {
         /* only actual matches are considered */
-        if (flags_to_max_width_in_bytes(
-                reading_swath_index->data[reading_iterator].match_info) > 0) {
+        if (reading_swath_index->data[reading_iterator].match_info.all_flags != 0) {
 
             if (i == n)
                 return (match_location){reading_swath_index, reading_iterator};
@@ -195,7 +194,7 @@ delete_by_region (matches_and_old_values_array *matches,
                                       &reading_swath_index->data[reading_iterator]);
 
             /* actual matches are recorded */
-            if (flags_to_max_width_in_bytes(flags) > 0)
+            if (flags.all_flags != 0)
                 ++(*num_matches);
         }
 

--- a/value.c
+++ b/value.c
@@ -260,29 +260,6 @@ void free_uservalue(uservalue_t *uval)
         free((void*)uval->wildcard_value);
 }
 
-int flags_to_max_width_in_bytes(match_flags flags)
-{
-    switch(sm_globals.options.scan_data_type)
-    {
-        case BYTEARRAY:
-        case STRING:
-            return flags.length;
-            break;
-        default: /* numbers */
-                 if (flags.u64b || flags.s64b || flags.f64b) return 8;
-            else if (flags.u32b || flags.s32b || flags.f32b) return 4;
-            else if (flags.u16b || flags.s16b              ) return 2;
-            else if (flags.u8b  || flags.s8b               ) return 1;
-            else    /* it can't be a variable of any size */ return 0;
-            break;
-    }
-}
-
-int val_max_width_in_bytes(const value_t *val)
-{
-	return flags_to_max_width_in_bytes(val->flags);
-}
-
 #define DEFINE_GET_BY_SYSTEM_DEPENDENT_TYPE_FUNCTION(type, typename, signedness_letter) \
 type get_##signedness_letter##typename (const value_t* val) \
 { \


### PR DESCRIPTION
This PR completely rehauls the interface with which the process memory is processed by `searchregions()` and the scan functions.

The main commit of the bunch is 0e44526 , which has the rationale, a through list of changes and the advantages we obtain.

Some discussion points:
* A packed struct (`mem64_t`) is introduced to operate on 8-bytes chunks regardless of alignment, instead of copying them out each time. This *should* work (and passes a full `-fsanitize=address,undefined` run on amd64), but needs through testing on ARM (and maybe on i386).
* To provide a common `searchregion()` interface I had `ptrace()` fill the `data` buffer even in the `!HAVE_PROCMEM` case. If the extra consumed memory in this case is unacceptable, I'm open to alternative solutions, like refilling a smaller buffer multiple times.
* Likewise, the `peekbuf` cache now needs to be large enough to contain the largest allowed VLT. As of now, that's 64kB (aka `UINT16_MAX`), if it's deemed too much we can lower the maximum VLT width to something more reasonable.

The advantage of all this? As usual, it's scan speed, and also improved endianness correctness.

I've put @sriemer and @bkazemi as reviewers, as usual. I'm not committing this one until you guys are satisfied, please ask about any problem you see.