### PR TITLE
Targetmem speedup

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -25,8 +25,6 @@
 # define _GNU_SOURCE
 #endif
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>

--- a/endianness.h
+++ b/endianness.h
@@ -95,11 +95,11 @@ static inline void fix_endianness(value_t *data_value, bool reverse_endianness)
     if (!reverse_endianness) {
         return;
     }
-    if (data_value->flags.u64b) {
+    if (data_value->flags & flags_64b) {
         data_value->uint64_value = swap_bytes64(data_value->uint64_value);
-    } else if (data_value->flags.u32b) {
+    } else if (data_value->flags & flags_32b) {
         data_value->uint32_value = swap_bytes32(data_value->uint32_value);
-    } else if (data_value->flags.u16b) {
+    } else if (data_value->flags & flags_16b) {
         data_value->uint16_value = swap_bytes16(data_value->uint16_value);
     }
     return;

--- a/handlers.c
+++ b/handlers.c
@@ -245,14 +245,11 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                     loc = nth_match(vars->matches, num);
                     if (loc.swath) {
                         value_t v;
-                        value_t old;
                         void *address = remote_address_of_nth_element(loc.swath, loc.index);
 
-                        /* copy val onto v */
+                        v = data_to_val(loc.swath, loc.index);
+                        /* copy userval onto v */
                         /* XXX: valcmp? make sure the sizes match */
-                        old = data_to_val(loc.swath, loc.index);
-                        zero_value(&v);
-                        v.flags = old.flags = loc.swath->data[loc.index].match_info;
                         uservalue2value(&v, &userval);
                         
                         show_info("setting *%p to %#"PRIx64"...\n", address, v.int64_value);
@@ -282,13 +279,10 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
                     if (reading_swath_index->data[reading_iterator].match_info.all_flags != 0)
                     {
                         void *address = remote_address_of_nth_element(reading_swath_index, reading_iterator);
-
-                        /* XXX: as above : make sure the sizes match */
-                                    
-                        value_t old = data_to_val(reading_swath_index, reading_iterator);
                         value_t v;
-                        zero_value(&v);
-                        v.flags = old.flags = reading_swath_index->data[reading_iterator].match_info;
+
+                        v = data_to_val(reading_swath_index, reading_iterator);
+                        /* XXX: as above : make sure the sizes match */
                         uservalue2value(&v, &userval);
 
                         show_info("setting *%p to %#"PRIx64"...\n", address, v.int64_value);
@@ -410,7 +404,6 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
             default: /* numbers */
                 ; /* cheat gcc */
                 value_t val = data_to_val(reading_swath_index, reading_iterator);
-                truncval_to_flags(&val, flags);
 
                 valtostr(&val, v, buf_len);
                 break;
@@ -1180,7 +1173,6 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
     address = remote_address_of_nth_element(loc.swath, loc.index);
     
     val = data_to_val(loc.swath, loc.index);
-    truncval_to_flags(&val, loc.swath->data[loc.index].match_info);
 
     if (INTERRUPTABLE()) {
         (void) sm_detach(vars->target);

--- a/handlers.c
+++ b/handlers.c
@@ -52,6 +52,7 @@
 #include "endianness.h"
 #include "handlers.h"
 #include "interrupt.h"
+#include "scanmem.h"
 #include "scanroutines.h"
 #include "sets.h"
 #include "show_message.h"
@@ -524,7 +525,7 @@ bool handler__reset(globals_t * vars, char **argv, unsigned argc)
     }
 
     /* read in maps if a pid is known */
-    if (vars->target && sm_readmaps(vars->target, vars->regions) != true) {
+    if (vars->target && sm_readmaps(vars->target, vars->regions, vars->options.region_scan_level) != true) {
         show_error("sorry, there was a problem getting a list of regions to search.\n");
         show_warn("the pid may be invalid, or you don't have permission.\n");
         vars->target = 0;

--- a/interrupt.h
+++ b/interrupt.h
@@ -20,6 +20,10 @@
 #ifndef INTERRUPT_H
 #define INTERRUPT_H
 
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE /* for sighandler_t */
+#endif
+
 #include <setjmp.h>
 #include <signal.h>
 

--- a/list.c
+++ b/list.c
@@ -19,8 +19,6 @@
     along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
-
 #include <stdlib.h>
 
 #include "list.h"

--- a/maps.c
+++ b/maps.c
@@ -26,8 +26,6 @@
 # define _GNU_SOURCE
 #endif
 
-#include "config.h"
-
 #include <stdio.h>
 #include <sys/types.h>
 #include <stddef.h>
@@ -40,12 +38,11 @@
 #include "list.h"
 #include "maps.h"
 #include "getline.h"
-#include "scanmem.h"
 #include "show_message.h"
 
 const char *region_type_names[] = REGION_TYPE_NAMES;
 
-bool sm_readmaps(pid_t target, list_t *regions)
+bool sm_readmaps(pid_t target, list_t *regions, region_scan_level_t region_scan_level)
 {
     FILE *maps;
     char name[128], *line = NULL;
@@ -190,7 +187,7 @@ bool sm_readmaps(pid_t target, list_t *regions)
                         type = REGION_TYPE_STACK;
 
                     /* determine if this region is useful */
-                    switch (sm_globals.options.region_scan_level)
+                    switch (region_scan_level)
                     {
                         case REGION_ALL:
                             useful = true;

--- a/maps.h
+++ b/maps.h
@@ -65,6 +65,6 @@ typedef struct {
     char filename[1];           /* associated file, must be last */
 } region_t;
 
-bool sm_readmaps(pid_t target, list_t *regions);
+bool sm_readmaps(pid_t target, list_t *regions, region_scan_level_t region_scan_level);
 
 #endif /* MAPS_H */

--- a/ptrace.c
+++ b/ptrace.c
@@ -332,7 +332,6 @@ bool sm_checkmatches(globals_t *vars,
         else if (old_flags.all_flags != 0) /* Test only valid old matches */
         {
             value_t old_val = data_to_val_aux(reading_swath_index, reading_iterator, reading_swath.number_of_bytes);
-            truncval_to_flags(&old_val, old_flags);
             memlength = old_length < memlength ? old_length : memlength;
 
             zero_match_flags(&checkflags);

--- a/ptrace.c
+++ b/ptrace.c
@@ -350,8 +350,8 @@ bool sm_checkmatches(globals_t *vars,
                - We can get away with assuming that the pointers will stay valid,
                  because as we never add more data to the array than there was before, it will not reallocate. */
 
-            old_value_and_match_info new_value = { get_u8b(memory_ptr), checkflags };
-            writing_swath_index = add_element((&vars->matches), writing_swath_index, address, &new_value);
+            writing_swath_index = add_element(&(vars->matches), writing_swath_index, address,
+                                              get_u8b(memory_ptr), checkflags);
 
             ++vars->num_matches;
 
@@ -359,8 +359,8 @@ bool sm_checkmatches(globals_t *vars,
         }
         else if (required_extra_bytes_to_record)
         {
-            old_value_and_match_info new_value = { get_u8b(memory_ptr), zero_flag };
-            writing_swath_index = add_element(&vars->matches, writing_swath_index, address, &new_value);
+            writing_swath_index = add_element(&(vars->matches), writing_swath_index, address,
+                                              get_u8b(memory_ptr), zero_flag);
             --required_extra_bytes_to_record;
         }
 
@@ -577,8 +577,8 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
             if (EXPECT(match_length > 0, false))
             {
                 assert(match_length <= memlength);
-                old_value_and_match_info new_value = { get_u8b(memory_ptr), checkflags };
-                writing_swath_index = add_element((&vars->matches), writing_swath_index, r->start+offset, &new_value);
+                writing_swath_index = add_element(&(vars->matches), writing_swath_index, r->start+offset,
+                                                  get_u8b(memory_ptr), checkflags);
                 
                 ++vars->num_matches;
                 
@@ -586,8 +586,8 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
             }
             else if (required_extra_bytes_to_record)
             {
-                old_value_and_match_info new_value = { get_u8b(memory_ptr), zero_flag };
-                writing_swath_index = add_element((&vars->matches), writing_swath_index, r->start+offset, &new_value);
+                writing_swath_index = add_element(&(vars->matches), writing_swath_index, r->start+offset,
+                                                  get_u8b(memory_ptr), zero_flag);
                 --required_extra_bytes_to_record;
             }
 

--- a/ptrace.c
+++ b/ptrace.c
@@ -65,6 +65,7 @@
 #include "scanroutines.h"
 #include "scanmem.h"
 #include "show_message.h"
+#include "targetmem.h"
 
 /* progress handling */
 #define NUM_DOTS (10)

--- a/scanmem.h
+++ b/scanmem.h
@@ -25,12 +25,14 @@
 #ifndef SCANMEM_H
 #define SCANMEM_H
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/types.h>
 
 #include "scanroutines.h"
 #include "list.h"
+#include "maps.h"
 #include "value.h"
 #include "targetmem.h"
 

--- a/scanroutines.c
+++ b/scanroutines.c
@@ -20,9 +20,8 @@
     along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
-
 #include <assert.h>
+#include <stdbool.h>
 
 #include "scanroutines.h"
 #include "common.h"

--- a/show_message.c
+++ b/show_message.c
@@ -19,8 +19,6 @@
     along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
-
 #include <stdio.h>
 #include <stdarg.h>
 

--- a/targetmem.c
+++ b/targetmem.c
@@ -20,8 +20,6 @@
     along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
-
 #include <string.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -31,6 +29,7 @@
 
 #include "targetmem.h"
 #include "show_message.h"
+#include "value.h"
 
 
 matches_and_old_values_array *

--- a/targetmem.c
+++ b/targetmem.c
@@ -133,7 +133,7 @@ nth_match (matches_and_old_values_array *matches, size_t n)
 
     while (reading_swath_index->first_byte_in_child) {
         /* only actual matches are considered */
-        if (reading_swath_index->data[reading_iterator].match_info.all_flags != 0) {
+        if (reading_swath_index->data[reading_iterator].match_info != flags_empty) {
 
             if (i == n)
                 return (match_location){reading_swath_index, reading_iterator};
@@ -195,7 +195,7 @@ delete_in_address_range (matches_and_old_values_array *array,
                                       old_byte.old_value, old_byte.match_info);
 
             /* actual matches are recorded */
-            if (old_byte.match_info.all_flags != 0)
+            if (old_byte.match_info != flags_empty)
                 ++(*num_matches);
         }
 

--- a/targetmem.c
+++ b/targetmem.c
@@ -179,9 +179,9 @@ delete_in_address_range (matches_and_old_values_array *array,
         void *address = reading_swath.first_byte_in_child + reading_iterator;
 
         if (address < start_address || address >= end_address) {
-            match_flags flags;
+            old_value_and_match_info old_byte;
 
-            flags = reading_swath_index->data[reading_iterator].match_info;
+            old_byte = reading_swath_index->data[reading_iterator];
 
             /* Still a candidate. Write data.
                 (We can get away with overwriting in the same array because
@@ -192,10 +192,10 @@ delete_in_address_range (matches_and_old_values_array *array,
                  there was before, it will not reallocate.) */
             writing_swath_index = add_element(&array,
                                       writing_swath_index, address,
-                                      &reading_swath_index->data[reading_iterator]);
+                                      old_byte.old_value, old_byte.match_info);
 
             /* actual matches are recorded */
-            if (flags.all_flags != 0)
+            if (old_byte.match_info.all_flags != 0)
                 ++(*num_matches);
         }
 

--- a/targetmem.h
+++ b/targetmem.h
@@ -179,7 +179,8 @@ static inline matches_and_old_values_swath *
 add_element (matches_and_old_values_array **array,
              matches_and_old_values_swath *swath,
              void *remote_address,
-             const old_value_and_match_info *new_element)
+             uint8_t new_byte,
+             match_flags new_flags)
 {
     if (swath->number_of_bytes == 0) {
         assert(swath->first_byte_in_child == NULL);
@@ -238,8 +239,9 @@ add_element (matches_and_old_values_array **array,
     }
 
     /* add me */
-    *(old_value_and_match_info *)local_address_beyond_last_element(swath) =
-        *new_element;
+    old_value_and_match_info *dataptr = local_address_beyond_last_element(swath);
+    dataptr->old_value = new_byte;
+    dataptr->match_info = new_flags;
     ++swath->number_of_bytes;
 
     return swath;

--- a/targetmem.h
+++ b/targetmem.h
@@ -31,7 +31,6 @@
 #include <stdbool.h>
 
 #include "value.h"
-#include "maps.h"
 #include "show_message.h"
 
 /* Public structs */

--- a/targetmem.h
+++ b/targetmem.h
@@ -276,6 +276,9 @@ data_to_val_aux (const matches_and_old_values_swath *swath,
         val.bytes[i] = swath->data[index + i].old_value;
     }
 
+    /* Truncate to the old flags, which are stored with the first matched byte */
+    val.flags.all_flags &= swath->data[index].match_info.all_flags;
+
     return val;
 }
 

--- a/value.c
+++ b/value.c
@@ -22,8 +22,6 @@
     along with this library.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include "config.h"
-
 #include <stdio.h>
 #include <ctype.h>
 #include <stdlib.h>
@@ -34,8 +32,6 @@
 #include <errno.h>
 
 #include "value.h"
-#include "scanroutines.h"
-#include "scanmem.h"
 #include "show_message.h"
 
 void valtostr(const value_t *val, char *str, size_t n)

--- a/value.h
+++ b/value.h
@@ -35,24 +35,41 @@
 
 /* some routines for working with value_t structures */
 
-/* this is memory-efficient but DANGEROUS */
-/* always keep in mind to not mess up with `length` when scanning for BYTEARRAY or STRING */
-typedef union {
-    struct __attribute__ ((packed)) {
-        unsigned  u8b:1;        /* could be an unsigned  8-bit variable (e.g. unsigned char)      */
-        unsigned u16b:1;        /* could be an unsigned 16-bit variable (e.g. unsigned short)     */
-        unsigned u32b:1;        /* could be an unsigned 32-bit variable (e.g. unsigned int)       */
-        unsigned u64b:1;        /* could be an unsigned 64-bit variable (e.g. unsigned long long) */
-        unsigned  s8b:1;        /* could be a    signed  8-bit variable (e.g. signed char)        */
-        unsigned s16b:1;        /* could be a    signed 16-bit variable (e.g. short)              */
-        unsigned s32b:1;        /* could be a    signed 32-bit variable (e.g. int)                */
-        unsigned s64b:1;        /* could be a    signed 64-bit variable (e.g. long long)          */
-        unsigned f32b:1;        /* could be a 32-bit floating point variable (i.e. float)         */
-        unsigned f64b:1;        /* could be a 64-bit floating point variable (i.e. double)        */
-    };
+/* match_flags: they MUST be implemented as an `uint16_t`, the `__packed__` ensures so.
+ * They are reinterpreted as a normal integer when scanning for VLT, which is
+ * valid for both endians, as the flags are ordered from smaller to bigger.
+ * NAMING: Primitive, single-bit flags are called `flag_*`, while aggregates,
+ * defined for convenience, are called `flags_*`*/
+typedef enum __attribute__((__packed__)) {
+    flags_empty = 0,
 
-    uint16_t length;       /* used when search for an array of bytes or text, I guess uint16_t is enough */
-    uint16_t all_flags;    /* used to access the whole union for bitwise operations */
+    flag_u8b  = 1 << 0,  /* could be an unsigned  8-bit variable (e.g. unsigned char)      */
+    flag_s8b  = 1 << 1,  /* could be a    signed  8-bit variable (e.g. signed char)        */
+    flag_u16b = 1 << 2,  /* could be an unsigned 16-bit variable (e.g. unsigned short)     */
+    flag_s16b = 1 << 3,  /* could be a    signed 16-bit variable (e.g. short)              */
+    flag_u32b = 1 << 4,  /* could be an unsigned 32-bit variable (e.g. unsigned int)       */
+    flag_s32b = 1 << 5,  /* could be a    signed 32-bit variable (e.g. int)                */
+    flag_u64b = 1 << 6,  /* could be an unsigned 64-bit variable (e.g. unsigned long long) */
+    flag_s64b = 1 << 7,  /* could be a    signed 64-bit variable (e.g. long long)          */
+
+    flag_f32b = 1 << 8,  /* could be a 32-bit floating point variable (i.e. float)         */
+    flag_f64b = 1 << 9,  /* could be a 64-bit floating point variable (i.e. double)        */
+
+    flags_i8b  = flag_u8b  | flag_s8b,
+    flags_i16b = flag_u16b | flag_s16b,
+    flags_i32b = flag_u32b | flag_s32b,
+    flags_i64b = flag_u64b | flag_s64b,
+
+    flags_integer = flags_i8b | flags_i16b | flags_i32b | flags_i64b,
+    flags_float = flag_f32b | flag_f64b,
+    flags_all = flags_integer | flags_float,
+
+    flags_8b   = flags_i8b,
+    flags_16b  = flags_i16b,
+    flags_32b  = flags_i32b | flag_f32b,
+    flags_64b  = flags_i64b | flag_f64b,
+
+    flags_max = 0xffffU /* ensures we're using an uint16_t */
 } match_flags;
 
 /* this struct describes matched values */
@@ -172,18 +189,12 @@ DECLARE_GET_BY_SYSTEM_DEPENDENT_TYPE_FUNCTIONS(int, int);
 DECLARE_GET_BY_SYSTEM_DEPENDENT_TYPE_FUNCTIONS(long, long);
 DECLARE_GET_BY_SYSTEM_DEPENDENT_TYPE_FUNCTIONS(long long, longlong);
 
-static inline void zero_match_flags(match_flags *flags)
-{
-    /* It's faster than a 2 bytes memset() */
-    flags->all_flags = 0;
-}
-
 static inline void zero_value(value_t *val)
 {
     /* zero components separately -
        10 bytes memset() is too slow */
     val->int64_value = 0;               /* zero the whole union */
-    zero_match_flags(&val->flags);
+    val->flags = flags_empty;
 }
 
 static inline void zero_uservalue(uservalue_t *val)

--- a/value.h
+++ b/value.h
@@ -191,19 +191,4 @@ static inline void zero_uservalue(uservalue_t *val)
     memset(val, 0, sizeof(*val));
 }
 
-static inline void truncval_to_flags(value_t *dst, match_flags flags)
-{
-    assert(dst != NULL);
-
-    /* Act on all numeric flags in a single go */
-    dst->flags.all_flags &= flags.all_flags;
-}
-
-static inline void truncval(value_t *dst, const value_t *src)
-{
-    assert(src != NULL);
-
-    truncval_to_flags(dst, src->flags);
-}
-
 #endif /* VALUE_H */


### PR DESCRIPTION
I'm pulling in a series of reworks that dramatically speed up storing data in the matches array, for a total of roughly 55% (measure as snapshot time, for which this was the bottleneck).

* First commit is mostly cosmetic, but I'd like someone to check when I touch the `set` handler
* Second should fully rationalize includes, I'd like to be sure it compiles on other distros as well, speed neutral
* 3rd and 5th are improvements to `add_element()`
* 4th is the main part, a full rework of the `match_flags` type, same interface but much saner (IMHO) implementation, for correctness, portability, speed and no absurd union-derived problems (like having to track the active member, otherwise performance suffers).

Comments welcome.