### PR TITLE
Add ranges support to `dregion`

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -648,7 +648,11 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc)
         {
             region_t *reg_to_delete = np->data;
 
-            if (!(vars->matches = delete_by_region(vars->matches, &vars->num_matches, reg_to_delete, false)))
+            void *start_address = reg_to_delete->start;
+            void *end_address = reg_to_delete->start + reg_to_delete->size;
+            vars->matches = delete_in_address_range(vars->matches, &vars->num_matches,
+                                                    start_address, end_address);
+            if (vars->matches == NULL)
             {
                 show_error("memory allocation error while deleting matches\n");
             }

--- a/handlers.h
+++ b/handlers.h
@@ -137,10 +137,11 @@ bool handler__pid(globals_t *vars, char **argv, unsigned argc);
 bool handler__snapshot(globals_t *vars, char **argv, unsigned argc);
 
 #define DREGION_SHRTDOC "delete a known region by region-id"
-#define DREGION_LONGDOC "usage: dregion [!]region-id[,region-id[,...]]\n" \
-                "Remove the region `region-id` from the regions list, along with any matches\n" \
-                "affected from the match list. The `region-id` can be found using the `lregions`\n" \
-                "command. A leading `!` indicates the list should be inverted.\n" 
+#define DREGION_LONGDOC "usage: dregion <region-id set>\n" \
+                "Remove a set of region-id from the regions list,\n" \
+                "along with any matches affected from the match list.\n" \
+                "The `region-id` can be found using the `lregions` command.\n\n" \
+                SET_FORMAT_DOC
 
 bool handler__dregion(globals_t *vars, char **argv, unsigned argc);
 

--- a/list.c
+++ b/list.c
@@ -147,7 +147,7 @@ void l_remove(list_t * list, element_t * element, void **data)
 }
 
 /* remove the nth element */
-void l_remove_nth(list_t * list, unsigned n, void **data)
+void l_remove_nth(list_t * list, size_t n, void **data)
 {
     element_t *np = list->head;
     

--- a/list.h
+++ b/list.h
@@ -26,7 +26,7 @@ typedef struct element {
 } element_t;
 
 typedef struct {
-    unsigned size;
+    size_t size;
     element_t *head;
     element_t *tail;
 } list_t;
@@ -44,7 +44,7 @@ int l_append(list_t * list, element_t * element, void *data);
 void l_remove(list_t * list, element_t * element, void **data);
 
 /* remove the nth element from head */
-void l_remove_nth(list_t * list, unsigned n, void **data);
+void l_remove_nth(list_t * list, size_t n, void **data);
 
 /* remove all elements from *src, and append to dst */
 int l_concat(list_t *dst, list_t **src);

--- a/targetmem.h
+++ b/targetmem.h
@@ -89,9 +89,11 @@ void data_to_bytearray_text (char *buf, int buf_length,
 
 match_location nth_match (matches_and_old_values_array *matches, size_t n);
 
-matches_and_old_values_array *delete_by_region (matches_and_old_values_array *array,
-                                                unsigned long *num_matches,
-                                                region_t *which, bool invert);
+/* deletes matches in [start, end) and resizes the matches array */
+matches_and_old_values_array *
+delete_in_address_range (matches_and_old_values_array *array,
+                         unsigned long *num_matches,
+                         void *start_address, void *end_address);
 
 /* The following functions are called in the hot scanning path and were moved
    to this header from the .c file so that they could be inlined */


### PR DESCRIPTION
Use the new set type to add ranges support to `dregion`, and update its documentation.

Also change `delete_by_region()` in `delete_in_address_range()`, which can be used for the same purpose (and maybe even exposed to users in a future handler), and allows targetmem to "not know" about maps.

I'd like this to go in before #275 , so I can add the extra include cleanup in the second commit of #275 .