### PR TITLE
Add new testing framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ missing
 py-compile
 stamp-h1
 tags
+test-driver
 
 # GameConqueror
 gui/GameConqueror.appdata.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,38 @@
 language: c
+sudo: required
+compiler: gcc-6
 
 env:
   global:
   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
   #   via the "travis encrypt" command using the project repo's public key
   - secure: "C3Gd8W9U0yQIxnUkcKlzicB2iOeZ42NPpVXTOnigjoc2UoI4eVYlDjEZjccZAIn0wHUguircvBt0eyLD7cuNf2mTozJ21BG0NpMdYbG1n/aVchnJBr6rldb2X3kVmQCj50LQKm+aINbK1qSs56VIUwNepPiul+HPMV6sL5sQ5M0="
+  - PATH=/usr/lib/binutils-2.26/bin:${PATH}
+  - ASAN_OPTIONS='halt_on_error=1'
+  - UBSAN_OPTIONS='halt_on_error=1'
 
 before_install:
-  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+  - if [ "${COVERITY_SCAN_BRANCH}" == 1 ]; then echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca- ; fi
 
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
-    - intltool
+    - gcc-6 binutils-2.26 intltool
   # Coverity scan add-on, fires only when pushing to the `coverity_scan` branch
   coverity_scan:
     project:
       name: "scanmem/scanmem"
       description: "Build submitted via Travis CI"
     notification_email: andreastacchiotti@gmail.com
-    build_command_prepend: "./autogen.sh && ./configure --enable-gui"
+    build_command_prepend: "./autogen.sh && ./configure"
     build_command: "make"
     branch_pattern: coverity_scan
 
 script:
-  - ./autogen.sh && ./configure --enable-gui && make
+  - if [ "${COVERITY_SCAN_BRANCH}" == 1 ]; then exit ; fi
+  - ./autogen.sh && ./configure --enable-gui
+  - make CFLAGS='-O2 -fsanitize=address,undefined'
+  # Testing requires `sudo` for `ptrace()`
+  - sudo make check VERBOSE=1

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,9 @@
 ACLOCAL_AMFLAGS = -I m4
 
+SUBDIRS = test
+
 if ENABLE_GUI
-  SUBDIRS = po gui
+  SUBDIRS += po gui
 endif
 
 # '-O2 -g' are added by `configure`, unless the user overrides CFLAGS

--- a/configure.ac
+++ b/configure.ac
@@ -107,6 +107,7 @@ AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE], ["$GETTEXT_PACKAGE"],
 
 AC_CONFIG_FILES([
   Makefile
+  test/Makefile
   po/Makefile.in
 ])
 

--- a/targetmem.h
+++ b/targetmem.h
@@ -47,7 +47,7 @@ typedef struct {
    - the number_of_bytes refers to the number of bytes in the child
      process's memory that are covered, not the number of bytes the struct
      takes up. It's the length of data. */
-typedef struct {
+typedef struct __attribute__((packed,aligned(sizeof(old_value_and_match_info)))) {
     void *first_byte_in_child;
     size_t number_of_bytes;
     old_value_and_match_info data[0];

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,6 @@
+# memfake exe
+memfake
+
+# Test results
+*.log
+*.trs

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,0 +1,5 @@
+TESTS = sm_test.sh
+check_PROGRAMS = memfake
+
+memfake_SOURCES = memfake.c
+memfake_CFLAGS = -std=gnu99 -Wall

--- a/test/memfake.c
+++ b/test/memfake.c
@@ -1,0 +1,52 @@
+/*
+    Provide a simple program to run test scans on
+
+    Copyright (C) 2017 Andrea Stacchiotti  <andreastacchiotti(a)gmail.com>
+
+    This library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+
+int main(int argc, char **argv)
+{
+    uint MB_to_allocate = 1;
+    bool add_randomness = false;
+
+    if (argc >= 2) MB_to_allocate = atoi(argv[1]);
+    if (argc >= 3) add_randomness = atoi(argv[2]);
+    if (argc >= 4) return 1;
+
+    size_t array_size = MB_to_allocate * 1024 * 1024 / sizeof(int);
+
+    int* array = calloc(array_size, sizeof(int));
+
+    // Fill half with random values and leave an half of zeroes, if asked to
+    if (add_randomness) {
+        srand(time(NULL));
+        for (size_t i = 0; i < array_size/2; i++) {
+            array[i] = rand();
+        }
+    }
+
+    pause();
+
+    free(array);
+    return 0;
+}
+

--- a/test/sm_test.sh
+++ b/test/sm_test.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -ev
+
+# Start memfake
+./memfake 4 1 &
+memfake_pid=$!
+
+# Test runs
+
+test_sm () {
+    ../scanmem -p $memfake_pid -e -c "$1"
+}
+
+test_sm "option scan_data_type int8;0;exit"
+test_sm "option scan_data_type int8;snapshot;exit"
+
+test_sm "option scan_data_type int8;snapshot;1;exit"
+test_sm "option scan_data_type int8;1;delete 0;1;exit"
+
+test_sm "option scan_data_type int;1;exit"
+test_sm "option scan_data_type float;1;exit"
+test_sm "option scan_data_type number;1;exit"
+
+huge_bytearray=""
+huge_string=""
+# 257 not a typo, forces full scan routine use
+for ((i=0; i < 257; i++)); do
+    huge_bytearray+="00 ?? "
+    huge_string+="a"
+done
+
+test_sm "option scan_data_type bytearray;${huge_bytearray};exit"
+test_sm "option scan_data_type string;\" ${huge_string};exit"
+
+# Clean up
+kill $memfake_pid


### PR DESCRIPTION
Add a very simple test script and configure the standard autotools facilities to run them.

The tests don't actually check the program output, but are intended to be used with gcc's sanitizers, to catch the sort of bugs that came up in #259 .

Add then the right configuration to `.travis.yml`, so that the tests run themselves automatically at each commit.

Adding for v0.17, comments and further testing ideas welcome.