### PR TITLE
cli: allow interrupts mid-scan

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -21,14 +21,15 @@ libscanmem_la_include_HEADERS = commands.h \
     sets.h \
     show_message.h \
     targetmem.h \
-    value.h
+    value.h \
+    interrupt.h
 
 libscanmem_la_SOURCES = commands.c \
     common.h \
     ptrace.c \
     handlers.h \
     handlers.c \
-    interrupt.h \
+    interrupt.c \
     list.c \
     licence.h \
     maps.c \

--- a/scanmem.h
+++ b/scanmem.h
@@ -44,7 +44,7 @@ typedef struct {
     matches_and_old_values_array *matches;
     unsigned long num_matches;
     double scan_progress;
-    bool stop_flag;
+    volatile bool stop_flag;
     list_t *regions;
     list_t *commands;              /* command handlers */
     const char *current_cmdline;   /* the command being executed */


### PR DESCRIPTION
Also:
* Add a new-line during an interrupt for cleaner output.
* s/intused/intr_used/ for clarity.
* New interrupt macro.