### PR TITLE
scanmem: Add persistence of command history

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,7 +11,8 @@ AM_CFLAGS = -std=gnu99 -Wall
 
 # Utilities library, statically linked in sm and libsm
 noinst_LTLIBRARIES = libutil.la
-libutil_la_SOURCES = show_message.c
+libutil_la_SOURCES = common.h \
+    show_message.c
 
 # libscanmem
 lib_LTLIBRARIES = libscanmem.la
@@ -28,7 +29,6 @@ libscanmem_la_include_HEADERS = commands.h \
     value.h
 
 libscanmem_la_SOURCES = commands.c \
-    common.h \
     ptrace.c \
     handlers.h \
     handlers.c \

--- a/common.h
+++ b/common.h
@@ -62,4 +62,11 @@
     })
 #endif
 
+/* Use the best `getenv()` implementation we have */
+#if HAVE_SECURE_GETENV
+# define util_getenv secure_getenv
+#else
+# define util_getenv getenv
+#endif
+
 #endif /* COMMON_H */

--- a/menu.c
+++ b/menu.c
@@ -206,6 +206,7 @@ bool getcommand(globals_t *vars, char **line)
                 show_error("sorry, there was a memory allocation error.\n");
                 return false;
             }
+            return true; /* exit immediately to not commit `__eof` to history */
         }
 
         if (strlen(*line)) {

--- a/readline.c
+++ b/readline.c
@@ -53,6 +53,7 @@ char *readline(const char *prompt)
 }
 
 /* don't maintain a history */
-void add_history(const char *line)
-{
-}
+void add_history(const char *line) {}
+int read_history (const char *filename) { return 0; }
+int write_history (const char *filename) { return 0; }
+int history_truncate_file (const char *filename, int nlines) { return 0; }

--- a/readline.h
+++ b/readline.h
@@ -34,6 +34,11 @@ extern rl_completion_func_t *rl_attempted_completion_function;
 char **rl_completion_matches(const char *text, rl_compentry_func_t
                              *entry_function);
 char *readline(const char *prompt);
+
+/* History, all doing nothing */
 void add_history(const char *line);
+int read_history (const char *filename);
+int write_history (const char *filename);
+int history_truncate_file (const char *filename, int nlines);
 
 #endif /* READLINE_H */

--- a/scanmem.1
+++ b/scanmem.1
@@ -300,6 +300,14 @@ Print a short summary of available commands.
 .B exit
 Detach from the target program and exit immediately.
 
+.SH HISTORY
+.RB "In interactive mode " scanmem " will retrieve the previous commands history
+at startup and update it at closure.
+.RI "The file used by default is " $XDG_CONFIG_HOME/scanmem/history " , which
+.RI "will be " ~/.config/scanmem/history " under normal configurations.
+.br
+The maximum size of the history is currently 1000 lines.
+
 .SH EXAMPLES
 Cheat at nethack, on systems where nethack is not installed sgid.
 

--- a/scanmem.h
+++ b/scanmem.h
@@ -36,12 +36,6 @@
 #include "value.h"
 #include "targetmem.h"
 
-#if HAVE_SECURE_GETENV
-#define util_getenv secure_getenv
-#else
-#define util_getenv getenv
-#endif
-
 
 /* global settings */
 typedef struct {

--- a/show_message.c
+++ b/show_message.c
@@ -23,6 +23,8 @@
 # define _GNU_SOURCE
 #endif
 
+#include "config.h"
+
 #include <stdio.h>
 #include <stdarg.h>
 #include <unistd.h>
@@ -32,6 +34,7 @@
 #include <signal.h>
 #include <fcntl.h>
 
+#include "common.h"
 #include "show_message.h"
 #include "scanmem.h"
 


### PR DESCRIPTION
Add to `main.c` the ability to save and reload the readline history from a config file, in simple cases being `$HOME/.config/scanmem/history`.

I'm not sure this is ready to be merged, it works pretty well and I'd like to hear people's opinions.
Maybe some switches/env to control the file location, or some other behaviour?
