### PR TITLE
Introduce util_getenv() based on secure_getenv()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ LT_INIT
 IT_PROG_INTLTOOL
 AM_PROG_CC_C_O
 
-AC_CHECK_FUNCS(memset strcasecmp strchr strdup strerror strtoul getline)
+AC_CHECK_FUNCS(getline secure_getenv)
 
 if test "x$ac_cv_func_getline" = "xno"; then
   AC_CHECK_FUNCS(fgetln)

--- a/handlers.c
+++ b/handlers.c
@@ -107,7 +107,7 @@ static FILE *get_pager(FILE *fallback_output)
     if (sm_globals.options.backend)
         return fallback_output;
 
-    if ((pager = getenv("PAGER")) == NULL || *pager == '\0') {
+    if ((pager = util_getenv("PAGER")) == NULL || *pager == '\0') {
         show_warn("get_pager(): couldn't get $PAGER, falling back to `more`\n");
         pager = "more";
     }

--- a/scanmem.h
+++ b/scanmem.h
@@ -36,6 +36,12 @@
 #include "value.h"
 #include "targetmem.h"
 
+#if HAVE_SECURE_GETENV
+#define util_getenv secure_getenv
+#else
+#define util_getenv getenv
+#endif
+
 
 /* global settings */
 typedef struct {


### PR DESCRIPTION
Check if `secure_getenv()` is available and define `util_getenv()` depending on that. On Android `secure_getenv()` is not available and `getenv()` is still used there instead.