### PR TITLE
Implement procmem support for `checkmatches`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ if test "x$ac_cv_func_getline" = "xno"; then
 fi
 AM_CONDITIONAL([HAVE_GETLINE], [test "x$ac_cv_func_getline" != "xno"])
 
-AC_CHECK_HEADERS(fcntl.h limits.h stddef.h sys/time.h)
+AC_CHECK_HEADERS(fcntl.h limits.h stddef.h sys/ioctl.h sys/time.h)
 
 AC_FUNC_ALLOCA
 AC_FUNC_STRTOD
@@ -86,6 +86,14 @@ AS_IF([test "x$android" = "xno"], [
   # /proc/pid/mem is there but reading interesting data fails
   AC_DEFINE(HAVE_PROCMEM, [0], [Enable /proc/pid/mem support])
 ])
+
+# Allows disabling procmem support
+AC_ARG_ENABLE(procmem, [AS_HELP_STRING([--disable-procmem],
+                         [forcefully disable proc/pid/mem support])])
+AS_IF([test "x$enable_procmem" = "xno"], [
+  AC_DEFINE(HAVE_PROCMEM, [0], [Enable /proc/pid/mem support])
+])
+
 
 # Check for termcap and readline or bypass checking for the libraries.
 AC_ARG_WITH([readline], [AS_HELP_STRING([--without-readline],

--- a/handlers.c
+++ b/handlers.c
@@ -1306,7 +1306,7 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
         if (sm_attach(vars->target) == false)
             return false;
 
-        if (sm_peekdata(vars->target, address, sizeof(uint64_t), &memory_ptr, &memlength) == false)
+        if (sm_peekdata(address, sizeof(uint64_t), &memory_ptr, &memlength) == false)
             return false;
 
         /* check if the new value is different */

--- a/scanmem.h
+++ b/scanmem.h
@@ -91,7 +91,7 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type,
                       const uservalue_t *uservalue);
 bool sm_peekdata(pid_t pid, const void *addr, uint16_t length, const mem64_t **result_ptr, size_t *memlength);
 bool sm_attach(pid_t target);
-bool sm_read_array(pid_t target, const void *addr, char *buf, int len);
-bool sm_write_array(pid_t target, void *addr, const void *data, int len);
+bool sm_read_array(pid_t target, const void *addr, void *buf, size_t len);
+bool sm_write_array(pid_t target, void *addr, const void *data, size_t len);
 
 #endif /* SCANMEM_H */

--- a/scanmem.h
+++ b/scanmem.h
@@ -89,7 +89,7 @@ bool sm_checkmatches(globals_t *vars, scan_match_type_t match_type,
                      const uservalue_t *uservalue);
 bool sm_searchregions(globals_t *vars, scan_match_type_t match_type,
                       const uservalue_t *uservalue);
-bool sm_peekdata(pid_t pid, const void *addr, uint16_t length, const mem64_t **result_ptr, size_t *memlength);
+bool sm_peekdata(const void *addr, uint16_t length, const mem64_t **result_ptr, size_t *memlength);
 bool sm_attach(pid_t target);
 bool sm_read_array(pid_t target, const void *addr, void *buf, size_t len);
 bool sm_write_array(pid_t target, void *addr, const void *data, size_t len);


### PR DESCRIPTION
The middle commit description contains a performance analysis, that I report:

* Memory is read in chunks of 2048 bytes, using larger chunks
  does not help dense scans further
* Dense checkmatches time is dramatically decreased, around 3-4x,
  as the bottleneck was starting each syscall
* Sparse checkmatches time changed as follows:
  * For values not found in the cache, `pread` is ~30% slower than
    `ptrace`, this could be mitigated by smaller chucks, but it
    cannot be brought below 10% even with chunk size below 8
  * Therefore, relative timing depends on "cache occupancy" of
    each chunk (2048 bytes),
    at 1.3 values per chunk on average they break even

The cases in which this new patch is slower are really absurd, the effect becomes noticeable (> 1 sec) at around 1M values, so you'd need to scan 1M optimally spaced (> 2kB) values, for a total of 2 GB.

All the testing has been done on my PC, amd64 with Debian kernel 4.14.17-1.
I'm not sure if this kernel has all the spectre/meltdown mitigations, but the general picture isn't going to change.
About the chunk size, I left it at the beginning of the dense plateau, but we could consider raising it to the full 64kB and getting rid of some logic and the loop, as the `missing_bytes` cannot be more than 64kB and improve cache occupancy.

Speed in the `!HAVE_PROCMEM` case is clearly unchanged, the compiler has no issue doing the nested inlining.

This probably needs testing on arm, I'll see if I can manage in the following days.

Related: #133 , #304 .