### PR TITLE
Add a utilities library

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,22 +18,22 @@ libscanmem_la_include_HEADERS = commands.h \
     maps.h \
     scanmem.h \
     scanroutines.h \
-    sets.h \
     show_message.h \
     targetmem.h \
-    value.h \
-    interrupt.h
+    value.h
 
 libscanmem_la_SOURCES = commands.c \
     common.h \
     ptrace.c \
     handlers.h \
     handlers.c \
+    interrupt.h \
     interrupt.c \
     licence.h \
     maps.c \
     scanmem.c \
     scanroutines.c \
+    sets.h \
     sets.c \
     show_message.c \
     targetmem.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,6 +9,11 @@ endif
 # '-O2 -g' are added by `configure`, unless the user overrides CFLAGS
 AM_CFLAGS = -std=gnu99 -Wall
 
+# Utilities library, statically linked in sm and libsm
+noinst_LTLIBRARIES = libutil.la
+libutil_la_SOURCES = show_message.c
+
+# libscanmem
 lib_LTLIBRARIES = libscanmem.la
 
 libscanmem_la_includedir = $(includedir)/scanmem
@@ -35,7 +40,6 @@ libscanmem_la_SOURCES = commands.c \
     scanroutines.c \
     sets.h \
     sets.c \
-    show_message.c \
     targetmem.c \
     value.c 
 
@@ -44,9 +48,12 @@ if !HAVE_GETLINE
       getline.c
 endif
 
-libscanmem_la_LDFLAGS = -version-info 1:0:0 \
-                        -export-symbols-regex '^sm_|^show_'
+libscanmem_la_LIBADD = libutil.la
 
+libscanmem_la_LDFLAGS = -version-info 1:0:0 \
+                        -export-symbols-regex '^sm_'
+
+# scanmem CLI
 bin_PROGRAMS = scanmem
 
 scanmem_SOURCES = menu.h \
@@ -58,8 +65,9 @@ if !WITH_READLINE
       readline.c
 endif
 
-scanmem_LDADD = libscanmem.la
+scanmem_LDADD = libutil.la libscanmem.la
 
+# Misc
 dist_man_MANS = scanmem.1
 dist_doc_DATA = README
 


### PR DESCRIPTION
As discussed in https://github.com/scanmem/scanmem/pull/302#issuecomment-366688523 , here is the dummy library implementation.

First commit just fixes the `HEADERS`, because new headers were added there by accident.

Second commit adds a library, `libutil.la`, that for now contains only `show_message.c`.
AM builds only the `.a` because of the `noinst` and then links it statically into both sm and libsm.

As a result the `show_*` functions can be dropped from the public API and everything still compiles.

Once this is merged I'll pick up #299 again, move `util_getenv` into its file and add said file to the `libutil_la_SOURCES`.