### PR TITLE
ptrace: Micro-optimize the comparison expressions in `sm_peekdata()`

### DIFF
--- a/ptrace.c
+++ b/ptrace.c
@@ -234,7 +234,7 @@ extern inline bool sm_peekdata(const void *addr, uint16_t length, const mem64_t 
     /* check if we have a full cache hit */
     if (peekbuf.base != NULL &&
         reqaddr >= peekbuf.base &&
-        (unsigned long) (reqaddr + length - peekbuf.base) <= peekbuf.size)
+        peekbuf.base - reqaddr + peekbuf.size - length >= 0)
     {
         *result_ptr = (mem64_t*)&peekbuf.cache[reqaddr - peekbuf.base];
         *memlength = peekbuf.base - reqaddr + peekbuf.size;
@@ -242,7 +242,7 @@ extern inline bool sm_peekdata(const void *addr, uint16_t length, const mem64_t 
     }
     else if (peekbuf.base != NULL &&
              reqaddr >= peekbuf.base &&
-             (unsigned long) (reqaddr - peekbuf.base) < peekbuf.size)
+             peekbuf.base - reqaddr + peekbuf.size > 0)
     {
         assert(peekbuf.size != 0);
 
@@ -569,7 +569,7 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
 
         /* read region into the `data` array */
         nread = readmemory(data, r->start, r->size);
-        if (nread == -1) {
+        if (nread == 0) {
             show_error("reading region %02u failed.\n", regnum);
             return false;
         }


### PR DESCRIPTION
I'm putting this single commit up for review because I'd like to merge this speedup, but I wonder if this isn't actually a slowdown for somebody else with a different compiler.

I'm also not sure when it's worth making the expressions messier for a speedup, but this 10% looks significant enough if you guys see it as well.

----------------------------------

Replace the expressions used for the cache decision with
mathematically equivalent ones (as overflow is impossible in this case),
but that the compiler can optimize better.

On my system (gcc-7, amd64) this saves 10% time in a `snapshot;1` scan.

This optimization is really unstable, as equally simple and functionally
equivalent changes lead to slower code, so those ugly expressions
might be rewritten better once compilers get smarter.

Also sneak in a trivial fix for a71e1520, as `readmemory()`
returns 0 on failure, not -1.