### PR TITLE
targetmem.h: replace uint with uint32_t

### DIFF
--- a/targetmem.h
+++ b/targetmem.h
@@ -257,7 +257,7 @@ static inline value_t
 data_to_val_aux (const matches_and_old_values_swath *swath,
                  size_t index, size_t swath_length)
 {
-    uint i;
+    uint32_t i;
     value_t val;
     size_t max_bytes = swath_length - index;
 


### PR DESCRIPTION
This is causing compilation issues for projects using the scanmem.h API that do not have a uint typedef.