### PR TITLE
scanmem.h: add sm_reset API

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -194,7 +194,7 @@ static inline void close_pager(FILE *pager)
     }
 }
 
-bool handler__set(globals_t * vars, char **argv, unsigned argc)
+static inline bool handler__set_unsafe(globals_t * vars, char **argv, unsigned argc)
 {
     unsigned block, seconds = 1;
     char *delay = NULL;
@@ -414,6 +414,14 @@ fail:
     ENDINTERRUPTABLE();
     return false;
     
+}
+
+bool handler__set(globals_t * vars, char **argv, unsigned argc)
+{
+    vars->scan_in_progress = true;
+    bool retval = handler__set_unsafe(vars, argv, argc);
+    vars->scan_in_progress = false;
+    return retval;
 }
 
 /* Accepts a numerical argument to print up to N matches, defaults to 10k

--- a/handlers.c
+++ b/handlers.c
@@ -617,17 +617,7 @@ bool handler__delete(globals_t * vars, char **argv, unsigned argc)
 bool handler__reset(globals_t * vars, char **argv, unsigned argc)
 {
     USEPARAMS();
-
-    /* reset scan progress */
-    vars->scan_progress = 0;
-
-    if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
-
-    /* refresh list of regions */
-    l_destroy(vars->regions);
-
-    /* create a new linked list of regions */
-    if ((vars->regions = l_init()) == NULL) {
+    if(!sm_reset(vars)) {
         show_error("sorry, there was a problem allocating memory.\n");
         return false;
     }

--- a/scanmem.c
+++ b/scanmem.c
@@ -244,3 +244,21 @@ void sm_set_stop_flag(bool stop_flag)
 {
     sm_globals.stop_flag = stop_flag;
 }
+
+bool sm_reset(globals_t* vars)
+{
+    /* reset scan progress */
+    vars->scan_progress = 0;
+
+    if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
+
+    /* refresh list of regions */
+    l_destroy(vars->regions);
+
+    /* create a new linked list of regions */
+    if ((vars->regions = l_init()) == NULL) {
+        return false;
+    }
+
+    return true;
+}

--- a/scanmem.c
+++ b/scanmem.c
@@ -247,6 +247,11 @@ void sm_set_stop_flag(bool stop_flag)
 
 bool sm_reset(globals_t* vars)
 {
+    if(vars->scan_in_progress) {
+        show_info("Cannot reset state when there is a scan in progress.");
+        return false;
+    }
+
     /* reset scan progress */
     vars->scan_progress = 0;
 

--- a/scanmem.h
+++ b/scanmem.h
@@ -67,6 +67,7 @@ typedef struct {
         unsigned short dump_with_ascii;
         unsigned short reverse_endianness;
     } options;
+    volatile bool scan_in_progress;
 } globals_t;
 
 /* global settings */

--- a/scanmem.h
+++ b/scanmem.h
@@ -94,4 +94,6 @@ bool sm_attach(pid_t target);
 bool sm_read_array(pid_t target, const void *addr, void *buf, size_t len);
 bool sm_write_array(pid_t target, void *addr, const void *data, size_t len);
 
+bool sm_reset(globals_t* vars);
+
 #endif /* SCANMEM_H */


### PR DESCRIPTION
This allows API users to avoid using `sm_init` and `sm_execcommand`just to use `sm_searchregions` and `sm_checkmatches` by allowing them to call `sm_reset` before `sm_readmaps`

I've also made sure that the "reset" command handler calls `sm_reset`