### PR TITLE
scanmem/GUI: Check if the target process is still running

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ AM_CFLAGS = -std=gnu99 -Wall
 # Utilities library, statically linked in sm and libsm
 noinst_LTLIBRARIES = libutil.la
 libutil_la_SOURCES = common.h \
+    common.c \
     show_message.c
 
 # libscanmem

--- a/common.c
+++ b/common.c
@@ -1,0 +1,94 @@
+/*
+    Common helper and utility functions
+
+    Copyright (C) 2018        Sebastian Parschauer  <s.parschauer(a)gmx.de>
+
+    This file is part of libscanmem.
+
+    This library is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published
+    by the Free Software Foundation; either version 3 of the License, or
+    (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this library.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+
+#include "common.h"
+
+/* states returned by check_process() */
+enum pstate {
+    PROC_RUNNING,
+    PROC_ERR,  /* error during detection */
+    PROC_DEAD,
+    PROC_ZOMBIE
+};
+
+/*
+ * We check if a process is running in /proc directly.
+ * Also zombies are detected.
+ *
+ * Requirements: Linux kernel, mounted /proc
+ * Assumption: (pid > 0)  --> Please check your PID before!
+ */
+static enum pstate check_process(pid_t pid)
+{
+    FILE *fp = NULL;
+    char *line = NULL;
+    size_t alloc_len = 0;
+    char status = '\0';
+    char path_str[128] = "/proc/";
+    int pr_len, path_len = sizeof("/proc/") - 1;
+
+    /* append $pid/status and check if file exists */
+    pr_len = sprintf((path_str + path_len), "%d/status", pid);
+    if (pr_len <= 0)
+        goto err;
+    path_len += pr_len;
+
+    fp = fopen(path_str, "r");
+    if (!fp) {
+        if (errno != ENOENT)
+            goto err;
+        else
+            return PROC_DEAD;
+    }
+
+    /* read process status */
+    while (getline(&line, &alloc_len, fp) != -1) {
+        if (alloc_len <= sizeof("State:\t"))
+            continue;
+        if (strncmp(line, "State:\t", sizeof("State:\t") - 1) == 0) {
+            status = line[sizeof("State:\t") - 1];
+            break;
+        }
+    }
+    if (line)
+        free(line);
+    fclose(fp);
+
+    if (status < 'A' || status > 'Z')
+       goto err;
+
+    /* zombies are not running - parent doesn't wait */
+    if (status == 'Z' || status == 'X')
+        return PROC_ZOMBIE;
+    return PROC_RUNNING;
+err:
+    return PROC_ERR;
+}
+
+bool sm_process_is_dead(pid_t pid)
+{
+    return (check_process(pid) != PROC_RUNNING);
+}

--- a/common.h
+++ b/common.h
@@ -1,5 +1,5 @@
 /*
-    Common macro and helpers.
+    Common macros and helpers.
 
     Copyright (C) 2017 Andrea Stacchiotti  <andreastacchiotti(a)gmail.com>
 
@@ -21,6 +21,9 @@
 
 #ifndef COMMON_H
 #define COMMON_H
+
+#include <stdbool.h>
+#include <sys/types.h>
 
 #ifndef MIN
 # define MIN(a,b) ((a) < (b) ? (a) : (b))
@@ -68,5 +71,8 @@
 #else
 # define util_getenv getenv
 #endif
+
+/* Function declarations */
+bool sm_process_is_dead(pid_t pid);
 
 #endif /* COMMON_H */

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -5,7 +5,7 @@
     Copyright (C) 2009-2011,2013 Wang Lu <coolwanglu(a)gmail.com>
     Copyright (C) 2010 Bryan Cain
     Copyright (C) 2013 Mattias Muenster <mattiasmun(a)gmail.com>
-    Copyright (C) 2014-2016 Sebastian Parschauer <s.parschauer(a)gmx.de>
+    Copyright (C) 2014-2018 Sebastian Parschauer <s.parschauer(a)gmx.de>
     Copyright (C) 2016-2017 Andrea Stacchiotti <andreastacchiotti(a)gmail.com>
     
     This program is free software: you can redistribute it and/or modify
@@ -1059,7 +1059,7 @@ class GameConqueror():
     def update_scan_result(self):
         match_count = self.backend.get_match_count()
         self.found_count_label.set_text(_('Found: %d') % (match_count,))
-        if (match_count > SCAN_RESULT_LIST_LIMIT):
+        if (match_count > SCAN_RESULT_LIST_LIMIT) or (self.backend.process_is_dead(self.pid)):
             self.scanresult_liststore.clear()
         else:
             self.command_lock.acquire()
@@ -1107,7 +1107,9 @@ class GameConqueror():
 
     # read/write data periodically
     def data_worker(self):
-        if (not self.is_scanning) and (self.pid != 0) and self.command_lock.acquire(0): # non-blocking
+        if (self.is_scanning) or (self.pid == 0) or (self.backend.process_is_dead(self.pid)):
+            return not self.exit_flag
+        if self.command_lock.acquire(0): # non-blocking
             Gdk.threads_enter()
 
             # Write to memory locked values in cheat list

--- a/gui/backend.py
+++ b/gui/backend.py
@@ -1,7 +1,8 @@
 """
-    GameConquerorBackend: communication with scanmem
+    GameConquerorBackend: communication with libscanmem
     
     Copyright (C) 2010,2011,2013 Wang Lu <coolwanglu(a)gmail.com>
+    Copyright (C) 2018 Sebastian Parschauer <s.parschauer(a)gmx.de>
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -33,7 +34,8 @@ class GameConquerorBackend():
         'sm_get_num_matches' : (ctypes.c_ulong, ),
         'sm_get_version' : (ctypes.c_char_p, ),
         'sm_get_scan_progress' : (ctypes.c_double, ),
-        'sm_set_stop_flag' : (ctypes.c_bool, )
+        'sm_set_stop_flag' : (None, ctypes.c_bool),
+        'sm_process_is_dead' : (ctypes.c_bool, ctypes.c_int32)
     }
 
     def __init__(self, libpath='libscanmem.so'):
@@ -81,3 +83,6 @@ class GameConquerorBackend():
 
     def exit_cleanup(self):
         self.lib.sm_cleanup()
+
+    def process_is_dead(self, pid):
+        return self.lib.sm_process_is_dead(pid)

--- a/handlers.c
+++ b/handlers.c
@@ -294,6 +294,11 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
 
         if (cont) {
             sleep(1);
+            if (sm_process_is_dead(vars->target)) {
+                vars->target = 0;
+                show_info("target process died, interrupting set operation.\n");
+                break;
+            }
         } else {
             break;
         }


### PR DESCRIPTION
    handlers: set: Introduce and use sm_check_process()
    
    For setting values continuously in target memory it is annoying
    having to interrupt the set handler manually once the target process
    terminates. A function to detect if a process is running, a zombie,
    or dead is required. The zombie and the error case should be treated
    as dead so that we see the unlikely case that the kernel interface
    changes.
    The required check_process() function has been implemented for
    ugtrain long time ago already and optimized recently. It checks if
    /proc/$pid/status exists while opening it with fopen(). Then it reads
    the first two lines with getline(), extracts the process state, and
    returns an enum value for this. The method has proven working.
    So take it over but without checking the process name. Set the target
    PID to 0 to avoid error messages when executing "reset" and break out
    of the set loop if the process is dead after sleeping for one second.
    
    Tested with Chromium B.S.U. lives, "set 0=9/1" as well as "set 0=9/5",
    and terminating the game after some cycles.
    
    Reference: #321

-----------------------------------------------------------------------------------------

    gui: Check target process before updating values
    
    The values in the scan results list are set to ?? when the target
    process terminates and errors are visible on the console. Those
    errors are also triggered if the data_worker() is running to lock/
    freeze values and to write them periodically.
    So make use of sm_check_process() from libscanmem, define the PROC_*
    constants in consts.py.in, and check if the process is running before
    doing the data_worker() or the update_scan_result() tasks.
    The scan results list and the value list stay at the last known
    values this way.
    
    Reference: #321
    Reported-by: @BluecoatEngineer