### PR TITLE
gui: Handle empty process name ValueError exception

### DIFF
--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -910,7 +910,16 @@ class GameConqueror():
     def get_process_list(self):
         plist = []
         for proc in os.popen('ps -wweo pid=,user:16=,command= --sort=-pid').readlines():
-            (pid, user, pname) = [tok.strip() for tok in proc.split(None, 2)]
+            try:
+                (pid, user, pname) = [tok.strip() for tok in proc.split(None, 2)]
+            # process name may be empty, but not the name of the executable
+            except (ValueError):
+                (pid, user) = [tok.strip() for tok in proc.split(None, 1)]
+                exelink = os.path.join("/proc", pid, "exe")
+                if os.path.exists(exelink):
+                    pname = os.path.realpath(exelink)
+                else:
+                    pname = ''
             plist.append((int(pid), user, pname))
         return plist
 


### PR DESCRIPTION
If a running application uses an empty process name
(argv[0][0] = '\0';), then an unhandled ValueError exception is
triggered when opening the process selection dialog.
The thing which can never be empty is the path to the executable.
So gather that one from the /proc/$pid/exe symlink to handle the
exception gracefully.

Reference: #328
Suggested-by: Thomas Hess (@luziferius)