### PR TITLE
treewide: Fix printf format issues

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -640,7 +640,7 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc)
 
         /* check if a match was found */
         if (np == NULL) {
-            show_warn("no region matching %u, or already removed.\n", reg_id);
+            show_warn("no region matching %lu, or already removed.\n", reg_id);
             continue;
         }
         
@@ -1176,7 +1176,7 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
 
     /* check that this is a valid match-id */
     if (!loc.swath) {
-        show_error("you specified a non-existent match `%u`.\n", id);
+        show_error("you specified a non-existent match `%lu`.\n", id);
         show_info("use \"list\" to list matches, or \"help\" for other commands.\n");
         return false;
     }

--- a/maps.c
+++ b/maps.c
@@ -252,7 +252,7 @@ bool sm_readmaps(pid_t target, list_t *regions, region_scan_level_t region_scan_
         }
     }
 
-    show_info("%d suitable regions found.\n", regions->size);
+    show_info("%lu suitable regions found.\n", regions->size);
     
     /* release memory allocated */
     free(line);

--- a/ptrace.c
+++ b/ptrace.c
@@ -483,7 +483,7 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
     matches_and_old_values_swath *writing_swath_index;
     int required_extra_bytes_to_record = 0;
     unsigned long total_size = 0;
-    unsigned regnum = 0;
+    unsigned long regnum = 0;
     element_t *n = vars->regions->head;
     region_t *r;
     unsigned long total_scan_bytes = 0;
@@ -568,7 +568,7 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
         }
 
         /* print a progress meter so user knows we haven't crashed */
-        show_user("%02u/%02u searching %#10lx - %#10lx", ++regnum,
+        show_user("%02lu/%02lu searching %#10lx - %#10lx", ++regnum,
                 vars->regions->size, (unsigned long)r->start, (unsigned long)r->start + r->size);
         fflush(stderr);
 


### PR DESCRIPTION
Coverity Scan reports four locations with printf format issues.
%u should be %lu or %d should be %lu. This issue has existed since
2009 with the 64 bit support introduction.
So fix the reported issues.

Fixes #351