### PR TITLE
.travis.yml: Drop docker build and build on Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,14 @@
 language: c
 sudo: required
-
-services:
-  - docker
+dist: bionic
 
 env:
   global:
   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
   #   via the "travis encrypt" command using the project repo's public key
   - secure: "C3Gd8W9U0yQIxnUkcKlzicB2iOeZ42NPpVXTOnigjoc2UoI4eVYlDjEZjccZAIn0wHUguircvBt0eyLD7cuNf2mTozJ21BG0NpMdYbG1n/aVchnJBr6rldb2X3kVmQCj50LQKm+aINbK1qSs56VIUwNepPiul+HPMV6sL5sQ5M0="
-  # Docker Ubuntu distribution and project directory in Docker container
-  - DUDIST="bionic"
-  - DPRJDIR="/scanmem"
-  - DEXEC="docker exec ${DUDIST} /bin/bash -c"
+  - ASAN_OPTIONS='halt_on_error=1'
+  - UBSAN_OPTIONS='halt_on_error=1'
 
 before_install:
   - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
@@ -33,14 +29,7 @@ addons:
 
 script:
   - if [ "${COVERITY_SCAN_BRANCH}" == 1 ]; then exit ; fi
-  - docker pull ubuntu:${DUDIST}
-  # mount the project git directory to the container and
-  # use it as working directory
-  - docker run -t -d --name="${DUDIST}" -v ${TRAVIS_BUILD_DIR}:${DPRJDIR} -w ${DPRJDIR} ubuntu:${DUDIST} /bin/bash
-  - docker ps
-  - ${DEXEC} "apt-get update && apt-get upgrade -y"
-  - ${DEXEC} "apt-get install -y git gcc binutils libtool intltool make libreadline-dev python"
-  - ${DEXEC} "gcc --version"
-  - ${DEXEC} "./autogen.sh && ./configure --enable-gui"
-  - ${DEXEC} "make CFLAGS='-O2 -fsanitize=address,undefined'"
-  - ${DEXEC} "export ASAN_OPTIONS='halt_on_error=1'; export UBSAN_OPTIONS='halt_on_error=1'; make check VERBOSE=1"
+  - ./autogen.sh && ./configure --enable-gui
+  - make CFLAGS='-O2 -fsanitize=address,undefined'
+  # Testing requires `sudo` for `ptrace()`
+  - sudo make check VERBOSE=1


### PR DESCRIPTION
The Docker build was just a workaround for gcc-7. Now Travis-CI
provides an Ubuntu Bionic VM image. We do not need the further layer
of complexity any more. So drop the Docker build and build on Bionic.

Fixes #350