### PR TITLE
show_message: check for terminal connection before getting pager

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -327,8 +327,7 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
     char *v = NULL;
     const char *bytearray_suffix = ", [bytearray]";
     const char *string_suffix = ", [string]";
-    struct winsize w;
-    FILE *pager;
+    FILE *pager = stdout;
 
     unsigned long max_to_print = 10000;
     if (argc > 1) {
@@ -355,13 +354,17 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
     matches_and_old_values_swath *reading_swath_index = vars->matches->swaths;
     size_t reading_iterator = 0;
 
-    if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == -1) {
-        if (!vars->options.backend)
+    if (isatty(STDOUT_FILENO)) {
+        struct winsize w;
+
+        if (ioctl(STDOUT_FILENO, TIOCGWINSZ, &w) == -1) {
             show_warn("handler__list(): couldn't get terminal size.\n");
-        pager = get_pager(stdout);
-    } else {
-        /* check if the output fits in the terminal window */
-        pager = (w.ws_row >= MIN(max_to_print, vars->num_matches)) ? stdout : get_pager(stdout);
+            pager = get_pager(stdout);
+        } else {
+            /* check if the output fits in the terminal window */
+            if (w.ws_row <= MIN(max_to_print, vars->num_matches))
+                pager = get_pager(stdout);
+        }
     }
 
     /* list all known matches */

--- a/show_message.c
+++ b/show_message.c
@@ -98,9 +98,9 @@ FILE *get_pager(FILE *fallback_output)
     FILE *retfd = NULL;
     char *const emptyvec[1] = { NULL };
 
-    assert(fallback_output != NULL);
+    assert(fallback_output != NULL && fileno(fallback_output) != -1);
 
-    if (sm_globals.options.backend)
+    if (sm_globals.options.backend || !isatty(fileno(fallback_output)))
         return fallback_output;
 
     if ((pager = util_getenv("PAGER")) == NULL || *pager == '\0') {


### PR DESCRIPTION
When scanmem is connected to a pipe or redirected to a file, stdout
is no longer associated with the terminal. This causes unnecessary
warning messages to appear. Add checks to avoid this.

handlers.c:
* Minor logic changes to pager code in handler__list().