### PR TITLE
maps: Replace alloca() with variable length array

### DIFF
--- a/maps.c
+++ b/maps.c
@@ -31,7 +31,6 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
-#include <alloca.h>
 #include <stdbool.h>
 #include <unistd.h>
 
@@ -88,15 +87,12 @@ bool sm_readmaps(pid_t target, list_t *regions, region_scan_level_t region_scan_
     while (getline(&line, &len, maps) != -1) {
         unsigned long start, end;
         region_t *map = NULL;
-        char read, write, exec, cow, *filename;
+        char read, write, exec, cow;
         int offset, dev_major, dev_minor, inode;
         region_type_t type = REGION_TYPE_MISC;
 
         /* slight overallocation */
-        if ((filename = alloca(len)) == NULL) {
-            show_error("failed to allocate %lu bytes for filename.\n", (unsigned long)len);
-            goto error;
-        }
+        char filename[len];
 
         /* initialise to zero */
         memset(filename, '\0', len);


### PR DESCRIPTION
When calling alloca() for the file name in the getline() loop, then
this allocates more and more memory on the stack for all file names
within the same maps file. It has no clue about the scope/block for
which it should keep the memory. It keeps it for the whole
sm_readmaps() function. With too many memory regions, this crashes.

So replace this with a variable length array as this one respects
the scope/block it is running in, restores the stack pointer at the
start of each loop cycle and only keeps one file name on the stack
at once this way.

Fixes #368