### PR TITLE
Added noptrace option

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -1674,6 +1674,23 @@ bool handler__option(globals_t * vars, char **argv, unsigned argc)
             return false;
         }
     }
+    else if (strcasecmp(argv[1], "noptrace") == 0)
+    {
+#if HAVE_PROCMEM
+        if (strcmp(argv[2], "0") == 0) {vars->options.no_ptrace = 0; }
+        else if (strcmp(argv[2], "1") == 0) {vars->options.no_ptrace = 1; }
+        else
+        {
+            show_error("bad value for noptrace, see `help option`.\n");
+            return false;      
+        }
+#else
+        show_error("\nThe option noptrace is not supported on your system.\n"
+                   "You might need to upgrade or reconfigure your kernel" 
+                   " to support reading and writing to /proc/pid/mem.\n");
+        return false;
+#endif
+    }
     else
     {
         show_error("unknown option specified, see `help option`.\n");

--- a/handlers.h
+++ b/handlers.h
@@ -331,7 +331,8 @@ bool handler__dump(globals_t *vars, char **argv, unsigned argc);
 bool handler__write(globals_t *vars, char **argv, unsigned argc);
 
 #define OPTION_COMPLETE "scan_data_type{number,int,float," VALUE_TYPES \
-    "},region_scan_level{1,2,3},dump_with_ascii{0,1},endianness{0,1,2}"
+    "},region_scan_level{1,2,3},dump_with_ascii{0,1},endianness{0,1,2}," \
+    "noptrace{0,1}"
 #define OPTION_SHRTDOC "set runtime options of scanmem, see `help option`"
 #define OPTION_LONGDOC "usage: option <option_name> <option_value>\n" \
                  "\n" \
@@ -372,6 +373,12 @@ bool handler__write(globals_t *vars, char **argv, unsigned argc);
                  "\t0:\thost endian\n" \
                  "\t1:\tlittle endian\n" \
                  "\t2:\tbig endian\n" \
+                 "\n" \
+                 "noptrace\tread/write without ptrace using /proc/pid/mem or using ptrace\n" \
+                 "\t\t\tDefault:0\n" \
+                 "\tpossibles values:\n"\
+                 "\t0:\tuse ptrace\n" \
+                 "\t1:\tno ptrace\n" \
                  "\n" \
                  "Example:\n" \
                  "\toption scan_data_type int32\n"

--- a/main.c
+++ b/main.c
@@ -207,6 +207,9 @@ static void parse_parameters(int argc, char **argv, char **initial_commands, boo
             case 'e':
                 *exit_on_error = true;
                 break;
+            case 'n':
+                vars->options.no_ptrace = 1;
+                break;
             case -1:
                 done = true;
                 break;
@@ -244,6 +247,18 @@ int main(int argc, char **argv)
         ret = EXIT_FAILURE;
         goto end;
     }
+
+#if !HAVE_PROCMEM
+    if (sm_globals.options.no_ptrace)
+    {
+        show_error("\nThe option noptrace is not supported on your system.\n"
+                   "You might need to upgrade or reconfigure your kernel" 
+                   " to support reading and writing to /proc/pid/mem.\n");
+
+        ret = EXIT_FAILURE;
+        goto end;
+    }   
+#endif
 
     if (getuid() != 0) {
         show_warn("Run scanmem as root if memory regions are missing. "

--- a/ptrace.c
+++ b/ptrace.c
@@ -96,19 +96,22 @@ static struct {
 
 bool sm_attach(pid_t target)
 {
-    int status;
+    if (!sm_globals.options.no_ptrace)
+    {
+        int status;
+        
+        /* attach to the target application, which should cause a SIGSTOP */
+        if (ptrace(PTRACE_ATTACH, target, NULL, NULL) == -1L) {
+            show_error("failed to attach to %d, %s\n", target, strerror(errno));
+            return false;
+        }
 
-    /* attach to the target application, which should cause a SIGSTOP */
-    if (ptrace(PTRACE_ATTACH, target, NULL, NULL) == -1L) {
-        show_error("failed to attach to %d, %s\n", target, strerror(errno));
-        return false;
-    }
-
-    /* wait for the SIGSTOP to take place. */
-    if (waitpid(target, &status, 0) == -1 || !WIFSTOPPED(status)) {
-        show_error("there was an error waiting for the target to stop.\n");
-        show_info("%s\n", strerror(errno));
-        return false;
+        /* wait for the SIGSTOP to take place. */
+        if (waitpid(target, &status, 0) == -1 || !WIFSTOPPED(status)) {
+            show_error("there was an error waiting for the target to stop.\n");
+            show_info("%s\n", strerror(errno));
+            return false;
+        }
     }
 
     /* reset the peek buffer */
@@ -124,7 +127,7 @@ bool sm_attach(pid_t target)
         snprintf(mem, sizeof(mem), "/proc/%d/mem", target);
 
         /* attempt to open the file */
-        if ((fd = open(mem, O_RDONLY)) == -1) {
+        if ((fd = open(mem, O_RDWR)) == -1) {
             show_error("unable to open %s.\n", mem);
             return false;
         }
@@ -146,9 +149,16 @@ bool sm_detach(pid_t target)
     close(peekbuf.procmem_fd);
 #endif
 
-    /* addr is ignored on Linux, but should be 1 on FreeBSD in order to let
-     * the child process continue execution where it had been interrupted */
-    return ptrace(PTRACE_DETACH, target, 1, 0) == 0;
+    if (!sm_globals.options.no_ptrace)
+    {
+        /* addr is ignored on Linux, but should be 1 on FreeBSD in order to let
+        * the child process continue execution where it had been interrupted */
+        return ptrace(PTRACE_DETACH, target, 1, 0) == 0;
+    }
+    else
+    {
+        return true;
+    }
 }
 
 
@@ -694,13 +704,26 @@ bool sm_setaddr(pid_t target, void *addr, const value_t *to)
         return false;
     }
 
-    /* TODO: may use /proc/<pid>/mem here */
-    /* Assume `sizeof(uint64_t)` is a multiple of `sizeof(long)` */
-    for (i = 0; i < sizeof(uint64_t); i += sizeof(long))
+    if (sm_globals.options.no_ptrace)
     {
-        if (ptrace(PTRACE_POKEDATA, target, addr + i, *(long*)(memarray + i)) == -1L) {
+#if HAVE_PROCMEM
+        if (pwrite(peekbuf.procmem_fd, memarray, sizeof(uint64_t), (long)addr) == -1) 
+        {
             return false;
         }
+#else
+        return false;
+#endif
+    }
+    else
+    {
+        /* Assume `sizeof(uint64_t)` is a multiple of `sizeof(long)` */
+        for (i = 0; i < sizeof(uint64_t); i += sizeof(long))
+        {
+            if (ptrace(PTRACE_POKEDATA, target, addr + i, *(long*)(memarray + i)) == -1L) {
+                return false;
+            }
+        }    
     }
 
     return sm_detach(target);
@@ -732,49 +755,63 @@ bool sm_write_array(pid_t target, void *addr, const void *data, size_t len)
         return false;
     }
 
-    for (i = 0; i + sizeof(long) < len; i += sizeof(long))
+    if (sm_globals.options.no_ptrace)
     {
-        if (ptrace(PTRACE_POKEDATA, target, addr + i, *(long *)(data + i)) == -1L) {
+#if HAVE_PROCMEM
+        if (pwrite(peekbuf.procmem_fd, data, len, (long)addr) == -1) 
+        {
             return false;
         }
+#else
+        return false;
+#endif
     }
-
-    if (len - i > 0) /* something left (shorter than a long) */
+    else
     {
-        if (len > sizeof(long)) /* rewrite last sizeof(long) bytes of the buffer */
+        for (i = 0; i + sizeof(long) < len; i += sizeof(long))
         {
-            if (ptrace(PTRACE_POKEDATA, target, addr + len - sizeof(long), *(long *)(data + len - sizeof(long))) == -1L) {
+            if (ptrace(PTRACE_POKEDATA, target, addr + i, *(long *)(data + i)) == -1L) {
                 return false;
             }
         }
-        else /* we have to play with bits... */
+
+        if (len - i > 0) /* something left (shorter than a long) */
         {
-            /* try all possible shifting read and write */
-            for(j = 0; j <= sizeof(long) - (len - i); ++j)
+            if (len > sizeof(long)) /* rewrite last sizeof(long) bytes of the buffer */
             {
-                errno = 0;
-                if(((peek_value = ptrace(PTRACE_PEEKDATA, target, addr - j, NULL)) == -1L) && (errno != 0))
-                {
-                    if (errno == EIO || errno == EFAULT) /* may try next shift */
-                        continue;
-                    else
-                    {
-                        show_error("%s failed.\n", __func__);
-                        return false;
-                    }
+                if (ptrace(PTRACE_POKEDATA, target, addr + len - sizeof(long), *(long *)(data + len - sizeof(long))) == -1L) {
+                    return false;
                 }
-                else /* peek success */
+            }
+            else /* we have to play with bits... */
+            {
+                /* try all possible shifting read and write */
+                for(j = 0; j <= sizeof(long) - (len - i); ++j)
                 {
-                    /* write back */
-                    memcpy(((int8_t*)&peek_value)+j, data+i, len-i);        
-
-                    if (ptrace(PTRACE_POKEDATA, target, addr - j, peek_value) == -1L)
+                    errno = 0;
+                    if(((peek_value = ptrace(PTRACE_PEEKDATA, target, addr - j, NULL)) == -1L) && (errno != 0))
                     {
-                        show_error("%s failed.\n", __func__);
-                        return false;
+                        if (errno == EIO || errno == EFAULT) /* may try next shift */
+                            continue;
+                        else
+                        {
+                            show_error("%s failed.\n", __func__);
+                            return false;
+                        }
                     }
+                    else /* peek success */
+                    {
+                        /* write back */
+                        memcpy(((int8_t*)&peek_value)+j, data+i, len-i);        
 
-                    break;
+                        if (ptrace(PTRACE_POKEDATA, target, addr - j, peek_value) == -1L)
+                        {
+                            show_error("%s failed.\n", __func__);
+                            return false;
+                        }
+
+                        break;
+                    }
                 }
             }
         }

--- a/scanmem.1
+++ b/scanmem.1
@@ -471,6 +471,41 @@ The
 .B snapshot
 command uses memory inefficiently, and should probably not be used on large programs.
 
+The option
+.B noptrace
+which uses /proc/pid/mem could be replaced by process_vm_readv/process_vm_writev system calls instead.
+.TP
+.br
+.B For more informations to this noptrace option:
+.br
+ 
+.br
+For now it runs by reading/writing only to /proc/pid/mem if available without having ptrace attached to the process.
+.br
+This is useful if you want to have a debugger attached to the targeted process and scanmem behind.
+.br
+You must have a recent kernel (Linux >= 3.2.2) to run with this option,
+.br
+in order to have permissions to read/write to /proc/pid/mem.
+.br
+ 
+.br
+.B Here is the details for the linux kernel if you want to know why:
+.RS
+.IP
+
+.br
+For linux kernel under versions 3.2.2,
+.br
+there was a check inside for the function(s) mem_read/mem_write,
+.br
+called previously check_mem_permission inside fs/proc/base.c,
+.br
+which needed ptrace permissions (process being attached to the targeted process).
+.br
+This has been removed after this version, and supported modifications to /proc/pid/mem directly with root.
+.RE
+
 .SH HOMEPAGE
 
 https://github.com/scanmem/scanmem

--- a/scanmem.h
+++ b/scanmem.h
@@ -60,6 +60,7 @@ typedef struct {
         region_scan_level_t region_scan_level;
         unsigned short dump_with_ascii;
         unsigned short reverse_endianness;
+        unsigned short no_ptrace;
     } options;
 } globals_t;
 


### PR DESCRIPTION
Hello dear scanmem developers,
I've made some changes that removes the needs of ptrace for newer kernels and tested it.
It's using /proc/pid/mem for now, which is useful for the tool in this issue:
https://github.com/scanmem/scanmem/issues/371

Though, it might be useful changing that and use
process_vm_readv/process_vm_writev system calls instead if they are available. (or make it as an option?)
This might be useful for a non-root user?

Let me know what you think,
thank you!