### PR TITLE
fixed broken HexView dispaly in none Latin locale system

### DIFF
--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -41,6 +41,7 @@ class BaseText(Gtk.TextView):
         self.override_font(Pango.FontDescription(parent.font))
         self.set_editable(False)
         self.texttag = self.buffer.create_tag(None)
+        self.texttag.set_property('fallback', False)
 
 GObject.type_register(BaseText)
 

--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -92,8 +92,11 @@ class OffsetText(BaseText):
         ctx = self.get_pango_context()
         font = ctx.load_font(Pango.FontDescription(self._parent.font))
         metric = font.get_metrics(ctx.get_language())
+        char_width_pango = max(
+            metric.get_approximate_char_width(),
+            metric.get_approximate_digit_width()) / Pango.SCALE
 
-        w = metric.get_approximate_char_width() / Pango.SCALE * (self.off_len + 1)
+        w = char_width_pango * self.off_len
         w += 2
 
         return w,w 
@@ -233,8 +236,11 @@ class AsciiText(BaseText):
         ctx = self.get_pango_context()
         font = ctx.load_font(Pango.FontDescription(self._parent.font))
         metric = font.get_metrics(ctx.get_language())
+        char_width_pango = max(
+            metric.get_approximate_char_width(),
+            metric.get_approximate_digit_width()) / Pango.SCALE
 
-        w = metric.get_approximate_char_width() / Pango.SCALE * self._parent.bpl
+        w = char_width_pango * self._parent.bpl
         w += 2
 
         return w,w
@@ -437,9 +443,11 @@ class HexText(BaseText):
         ctx = self.get_pango_context()
         font = ctx.load_font(Pango.FontDescription(self._parent.font))
         metric = font.get_metrics(ctx.get_language())
+        char_width_pango = max(
+            metric.get_approximate_char_width(),
+            metric.get_approximate_digit_width()) / Pango.SCALE
 
-        w = metric.get_approximate_char_width() / Pango.SCALE * \
-                        (self._parent.bpl * 3 - 1)
+        w = char_width_pango * self._parent.bpl * 3
         w += 2
         return w,w
 


### PR DESCRIPTION
346de29..7cb8662
Those two commits fixed broken HexView dispaly in none Latin locale system.
Tested on Fedora 32 x86_64 LANG=[C, en_US, de_DE, en_UK, it_IT, zh_TW, zh_HK, ja_JP].

c9af3b7
Make sure test program also follow same AM_CFLAGS and take extra CFLAGS from ./configure CFLAGS=xxx
P.S: I got 4%~6% faster scan ./configure with CFLAGS=-O3 -g -march=native then CFLAGS=-O2 -g by compile with gcc 10 :smile:

Please be kind to review those changes.