### PR TITLE
Fix warning when compile with -Wextra flags and fix for potential bug.

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -1271,7 +1271,7 @@ bool handler__dump(globals_t * vars, char **argv, unsigned argc)
     void *addr;
     char *endptr;
     char *buf = NULL;
-    int len;
+    unsigned len;
     bool dump_to_file = false;
     FILE *dump_f = NULL;
 
@@ -1349,7 +1349,7 @@ bool handler__dump(globals_t * vars, char **argv, unsigned argc)
         else
         {
             /* print it out nicely */
-            int i,j;
+            unsigned i,j;
             int buf_idx = 0;
             for (i = 0; i + 16 < len; i += 16)
             {

--- a/handlers.c
+++ b/handlers.c
@@ -90,9 +90,10 @@
 
 bool handler__set(globals_t * vars, char **argv, unsigned argc)
 {
-    unsigned block, seconds = 1;
+    unsigned block;
+	volatile unsigned seconds = 1;
     char *delay = NULL;
-    bool cont = false;
+    volatile bool cont = false;
     struct setting {
         char *matchids;
         char *value;

--- a/ptrace.c
+++ b/ptrace.c
@@ -748,7 +748,7 @@ bool sm_read_array(pid_t target, const void *addr, void *buf, size_t len)
 /* TODO: may use /proc/<pid>/mem here */
 bool sm_write_array(pid_t target, void *addr, const void *data, size_t len)
 {
-    int i,j;
+    unsigned i,j;
     long peek_value;
 
     if (sm_attach(target) == false) {

--- a/scanmem.c
+++ b/scanmem.c
@@ -64,9 +64,10 @@ globals_t sm_globals = {
         0,                      /* debug */
         0,                      /* backend */
         ANYINTEGER,             /* scan_data_type */
-        REGION_HEAP_STACK_EXECUTABLE_BSS, /* region_detail_level */ 
+        REGION_HEAP_STACK_EXECUTABLE_BSS, /* region_detail_level */
         1,                      /* dump_with_ascii */
         0,                      /* reverse_endianness */
+        0,                      /* no_ptrace */
     }
 };
 

--- a/targetmem.h
+++ b/targetmem.h
@@ -258,7 +258,7 @@ data_to_val_aux (const matches_and_old_values_swath *swath,
                  size_t index, size_t swath_length)
 {
     unsigned int i;
-    value_t val;
+    volatile value_t val;
     size_t max_bytes = swath_length - index;
 
     /* Init all possible flags in a single go.

--- a/value.c
+++ b/value.c
@@ -74,7 +74,7 @@ void valtostr(const value_t *val, char *str, size_t n)
         show_debug("BUG: No formatting found\n");
         goto err;
     }
-    if (np <= 0 || np >= (n - 1))
+    if (np <= 0 || (size_t)np >= (n - 1))
         goto err;
 
     return;
@@ -115,7 +115,7 @@ void uservalue2value(value_t *dst, const uservalue_t *src)
 /* parse bytearray, it will allocate the arrays itself, then needs to be free'd by `free_uservalue()` */
 bool parse_uservalue_bytearray(char *const *argv, unsigned argc, uservalue_t *val)
 {
-    int i,j;
+    unsigned i,j;
     uint8_t *bytes_array = malloc(argc*sizeof(uint8_t));
     wildcard_t *wildcards_array = malloc(argc*sizeof(wildcard_t));
 


### PR DESCRIPTION
Fix warning when compile with -Wextra flags.

Including fix for potential bug cause by  sigsetjmp, siglongjmp in interrupt.c and interrupt.h.

Unsigned counter(i, j) also helps compiler gen hardware instructions to prevent underflow to negative value when needed.

np may become o or negative value from snprintf when out of memory. But we already check <=0 case. Simply cast to size_t then comparing is safe.