### PR TITLE
Split Wclobbered fixup from pull request #377

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -90,9 +90,9 @@
 
 bool handler__set(globals_t * vars, char **argv, unsigned argc)
 {
-    unsigned block, seconds = 1;
+    unsigned block, seconds;
     char *delay = NULL;
-    bool cont = false;
+    bool cont;
     struct setting {
         char *matchids;
         char *value;
@@ -128,6 +128,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
     settings = calloca(argc - 1, sizeof(struct setting));
 
     /* parse every block into a settings struct */
+    cont = false;
     for (block = 0; block < argc - 1; block++) {
 
         /* first separate the block into matches and value, which are separated by '=' */
@@ -194,6 +195,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
 
     /* --- execute the parsed setting structs --- */
 
+    seconds = 1;
     while (true) {
         uservalue_t userval;
 

--- a/interrupt.c
+++ b/interrupt.c
@@ -29,7 +29,7 @@
 
 sigjmp_buf jmpbuf;       /* used when aborting a command due to an interrupt */
 sighandler_t oldsig;     /* reinstalled before longjmp */
-unsigned intr_used;
+volatile sig_atomic_t intr_used;
 
 /* signal handler used to handle an interrupt during commands */
 void interrupted(int n)

--- a/interrupt.h
+++ b/interrupt.h
@@ -29,7 +29,7 @@
 
 extern sigjmp_buf jmpbuf;       /* used when aborting a command due to an interrupt */
 extern sighandler_t oldsig;     /* reinstalled before longjmp */
-extern unsigned intr_used;
+extern volatile sig_atomic_t intr_used;
 
 /* signal handler used to handle an interrupt during commands */
 void interrupted(int);

--- a/targetmem.h
+++ b/targetmem.h
@@ -258,7 +258,7 @@ data_to_val_aux (const matches_and_old_values_swath *swath,
                  size_t index, size_t swath_length)
 {
     unsigned int i;
-    value_t val;
+    volatile value_t val;
     size_t max_bytes = swath_length - index;
 
     /* Init all possible flags in a single go.


### PR DESCRIPTION
https://github.com/scanmem/scanmem/pull/377#issuecomment-623762128
https://github.com/scanmem/scanmem/pull/377#discussion_r420419049
https://github.com/scanmem/scanmem/pull/377#issuecomment-623849478
https://github.com/scanmem/scanmem/pull/377#issuecomment-624323867

Some variable might be clobbered by sigsetjmp, siglongjmp in interrupt .c and .h.
Which means value in register or stack may not safe in some aggressive optimization.

Another way to fix Wextra warnings: Wclobbered without using gcc attribute

Signed-off-by: Dark Shenada <shenada@gmail.com>