### PR TITLE
Split Wsign-compare fixup from pull request #377

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -1271,7 +1271,7 @@ bool handler__dump(globals_t * vars, char **argv, unsigned argc)
     void *addr;
     char *endptr;
     char *buf = NULL;
-    int len;
+    unsigned len;
     bool dump_to_file = false;
     FILE *dump_f = NULL;
 
@@ -1349,7 +1349,7 @@ bool handler__dump(globals_t * vars, char **argv, unsigned argc)
         else
         {
             /* print it out nicely */
-            int i,j;
+            unsigned i,j;
             int buf_idx = 0;
             for (i = 0; i + 16 < len; i += 16)
             {

--- a/ptrace.c
+++ b/ptrace.c
@@ -753,7 +753,7 @@ bool sm_read_array(pid_t target, const void *addr, void *buf, size_t len)
 /* TODO: may use /proc/<pid>/mem here */
 bool sm_write_array(pid_t target, void *addr, const void *data, size_t len)
 {
-    int i,j;
+    unsigned i,j;
     long peek_value;
 
     if (sm_attach(target) == false) {

--- a/value.c
+++ b/value.c
@@ -74,7 +74,7 @@ void valtostr(const value_t *val, char *str, size_t n)
         show_debug("BUG: No formatting found\n");
         goto err;
     }
-    if (np <= 0 || np >= (n - 1))
+    if (np <= 0 || (size_t)np >= (n - 1))
         goto err;
 
     return;
@@ -115,7 +115,7 @@ void uservalue2value(value_t *dst, const uservalue_t *src)
 /* parse bytearray, it will allocate the arrays itself, then needs to be free'd by `free_uservalue()` */
 bool parse_uservalue_bytearray(char *const *argv, unsigned argc, uservalue_t *val)
 {
-    int i,j;
+    unsigned i,j;
     uint8_t *bytes_array = malloc(argc*sizeof(uint8_t));
     wildcard_t *wildcards_array = malloc(argc*sizeof(wildcard_t));
 


### PR DESCRIPTION
https://github.com/scanmem/scanmem/pull/377#issue-406035762
https://github.com/scanmem/scanmem/pull/377#issuecomment-623762128

Fix Wextra warnings: Wsign-compare
Signed-off-by: Dark Shenada <shenada@gmail.com>