### PR TITLE
Add support to ppc64le focal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: c
 sudo: required
 dist: bionic
 
+jobs:
+  include:
+    - arch: amd64
+      dist: bionic
+    - arch: ppc64le
+      dist: focal   
 env:
   global:
   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.
