### PR TITLE
enable searching in read-only memory (PR for issue #406)

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -1651,7 +1651,8 @@ bool handler__option(globals_t * vars, char **argv, unsigned argc)
     {
         if (strcmp(argv[2], "1") == 0) {vars->options.region_scan_level = REGION_HEAP_STACK_EXECUTABLE; }
         else if (strcmp(argv[2], "2") == 0) {vars->options.region_scan_level = REGION_HEAP_STACK_EXECUTABLE_BSS; }
-        else if (strcmp(argv[2], "3") == 0) {vars->options.region_scan_level = REGION_ALL; }
+        else if (strcmp(argv[2], "3") == 0) {vars->options.region_scan_level = REGION_ALL_RW; }
+        else if (strcmp(argv[2], "4") == 0) {vars->options.region_scan_level = REGION_ALL; }
         else
         {
             show_error("bad value for region_scan_level, see `help option`.\n");

--- a/handlers.h
+++ b/handlers.h
@@ -331,7 +331,7 @@ bool handler__dump(globals_t *vars, char **argv, unsigned argc);
 bool handler__write(globals_t *vars, char **argv, unsigned argc);
 
 #define OPTION_COMPLETE "scan_data_type{number,int,float," VALUE_TYPES \
-    "},region_scan_level{1,2,3},dump_with_ascii{0,1},endianness{0,1,2}," \
+    "},region_scan_level{1,2,3,4},dump_with_ascii{0,1},endianness{0,1,2}," \
     "noptrace{0,1}"
 #define OPTION_SHRTDOC "set runtime options of scanmem, see `help option`"
 #define OPTION_LONGDOC "usage: option <option_name> <option_value>\n" \
@@ -357,7 +357,8 @@ bool handler__write(globals_t *vars, char **argv, unsigned argc);
                  "\tPossible Values:\n" \
                  "\t1:\theap, stack and executable only\n" \
                  "\t2:\theap, stack executable and bss only\n" \
-                 "\t3:\teverything(e.g. other libs)\n" \
+                 "\t3:\tall writable memory (including other libs)\n" \
+                 "\t4:\teverything\n" \
                  "\n" \
                  "dump_with_ascii\twhether to print ascii characters with a memory dump\n" \
                  "\t\t\tDefault:1\n" \

--- a/maps.h
+++ b/maps.h
@@ -32,7 +32,8 @@
 
 /* determine which regions we need */
 typedef enum {
-    REGION_ALL,                            /* each of them */
+    REGION_ALL,                            /* All regions, including non-writable regions */
+    REGION_ALL_RW,                         /* each of them */
     REGION_HEAP_STACK_EXECUTABLE,          /* heap, stack, executable */
     REGION_HEAP_STACK_EXECUTABLE_BSS       /* heap, stack, executable, bss */
 } region_scan_level_t;


### PR DESCRIPTION
Hi,

I also ran into issue https://github.com/scanmem/scanmem/issues/406
This functionality is important for scanning executable regions.
Specifically for AOB scanning in game hacking this is an incredibly useful feature.
Merging this should also enable this feature for PINCE (https://github.com/korcankaraokcu/PINCE)