### PR TITLE
Use 'unsigned int' instead of unofficial alias 'uint'

### DIFF
--- a/ptrace.c
+++ b/ptrace.c
@@ -392,7 +392,7 @@ bool sm_checkmatches(globals_t *vars,
         match_flags checkflags;
 
         match_flags old_flags = reading_swath_index->data[reading_iterator].match_info;
-        uint old_length = flags_to_memlength(vars->options.scan_data_type, old_flags);
+        unsigned int old_length = flags_to_memlength(vars->options.scan_data_type, old_flags);
         void *address = reading_swath.first_byte_in_child + reading_iterator;
 
         /* read value from this address */
@@ -699,7 +699,7 @@ bool sm_setaddr(pid_t target, void *addr, const value_t *to)
         return false;
     }
 
-    uint val_length = flags_to_memlength(ANYNUMBER, to->flags);
+    unsigned int val_length = flags_to_memlength(ANYNUMBER, to->flags);
     if (val_length > 0) {
         /* Basically, overwrite as much of the data as makes sense, and no more. */
         memcpy(memarray, to->bytes, val_length);

--- a/scanroutines.c
+++ b/scanroutines.c
@@ -369,7 +369,7 @@ extern inline unsigned int scan_routine_BYTEARRAY_EQUALTO SCAN_ROUTINE_ARGUMENTS
 {
     const uint8_t *bytes_array = user_value->bytearray_value;
     const wildcard_t *wildcards_array = user_value->wildcard_value;
-    uint length = user_value->flags;
+    unsigned int length = user_value->flags;
     if (memlength < length ||
         *((uint64_t*)bytes_array) != (memory_ptr->uint64_value & *((uint64_t*)wildcards_array)))
     {
@@ -470,7 +470,7 @@ DEFINE_BYTEARRAY_SMALLOOP_EQUALTO_ROUTINE(56)
 extern inline unsigned int scan_routine_STRING_EQUALTO SCAN_ROUTINE_ARGUMENTS
 {
     const char *scan_string = user_value->string_value;
-    uint length = user_value->flags;
+    unsigned int length = user_value->flags;
     if(memlength < length ||
        memory_ptr->int64_value != *((int64_t*)scan_string))
     {


### PR DESCRIPTION
glibc headers have 'uint' typedef'd to 'unsigned int', but this isn't guaranteed to be avaialble. Change to 'unsigned int' which is equivalent to fix building on musl.

Bug: https://bugs.gentoo.org/854840