### PR TITLE
Change lregions command to output to stdout instead of stderr

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -687,7 +687,7 @@ bool handler__lregions(globals_t * vars, char **argv, unsigned argc)
     while (np) {
         region_t *region = np->data;
 
-        fprintf(stderr, "[%2u] "POINTER_FMT", %7lu bytes, %5s, "POINTER_FMT", %c%c%c, %s\n", 
+        fprintf(stdout, "[%2u] "POINTER_FMT", %7lu bytes, %5s, "POINTER_FMT", %c%c%c, %s\n",
                 region->id,
                 (unsigned long)region->start, region->size,
                 region_type_names[region->type], region->load_addr,


### PR DESCRIPTION
We stumbled upon a little issue in our own fork where we tried using `send_command`'s `get_output` parameter inside `scanmem.py` wrapper to retrieve the memory regions, but that only captures the stdout descriptor where lregions command outputs to stderr.

Another way to fix this would be to change `get_output` to also capture stderr but that would also grab other outputs that might not be necessary to programs using this as a library. This is why I opted to just change lregions' stderr to stdout so it's in line with other commands that have similar output, like list.

I'm not sure why we would want to output normal info to stderr instead of stdout for this case, unless the unbuffered aspect is desired particularly for this command.