### PR TITLE
scanmem 0.18.0: security hardening + backlog fixes

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,1 +1,24 @@
-See https://github.com/scanmem/scanmem/releases for news.
+scanmem 0.18.0 (2026-08-01)
+===========================
+
+Security and stability
+----------------------
+* Harden printable-string and bytearray formatting bounds (#449)
+* Cap /proc maps pathname buffer; fix sscanf field types (#452)
+* Clamp ptrace poke length to mapped buffer size
+* Replace shell command with execvp for the shell handler
+* Read process list from /proc instead of ps popen (#434)
+
+Compiler / portability
+----------------------
+* Silence -Wclobbered in handler__set (#381)
+* Use sig_atomic_t for interrupt flag
+* Mark data_to_val_aux scratch value as volatile
+* Require Gtk 3 before PyGI imports (#398)
+* Launch GameConqueror with python3 (#438)
+* Pick Android cross compiler from HOST (#441)
+
+GUI
+---
+* Memory viewer display type selector (#448)
+* Georgian translation (#426)

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-scanmem 0.18.0 (2026-08-01)
+scanmem 0.18.0 (unreleased)
 ===========================
 
 Security and stability

--- a/build_for_android.sh
+++ b/build_for_android.sh
@@ -149,18 +149,38 @@ if [ "$(uname -s)" = "Darwin" ]; then
   PATH=/usr/local/opt/gettext/bin:${PATH} # brew install gettext
 fi
 
-# NDK llvm toolchains need an explicit cross compiler or configure picks the host.
+# NDK r19+ names the compiler with an API level baked in (e.g.
+# aarch64-linux-android21-clang) and ships no unsuffixed symlink, so configure
+# quietly falls back to the host cc and builds for the wrong arch. Pick one
+# explicitly. Set CC yourself, or API_LEVEL, to override the search.
 if [ -z "${CC}" ]; then
   if command -v "${HOST}-clang" >/dev/null 2>&1; then
-    export CC="${HOST}-clang"
-  elif command -v "${HOST}21-clang" >/dev/null 2>&1; then
-    export CC="${HOST}21-clang"
-  elif command -v "${HOST}-gcc" >/dev/null 2>&1; then
-    export CC="${HOST}-gcc"
+    CC="${HOST}-clang"
+  elif [ -n "${API_LEVEL}" ] && command -v "${HOST}${API_LEVEL}-clang" >/dev/null 2>&1; then
+    CC="${HOST}${API_LEVEL}-clang"
   else
-    echo "Error: no cross compiler found for HOST=${HOST}" 1>&2
+    # no plain name and no API_LEVEL given, take the lowest API level on PATH
+    CC=$(IFS=:
+         for dir in $PATH; do
+           for cand in "${dir}/${HOST}"[0-9]*-clang; do
+             [ -x "${cand}" ] || continue
+             base=${cand##*/}
+             api=${base#${HOST}}
+             api=${api%-clang}
+             case "${api}" in *[!0-9]*) continue ;; esac
+             printf '%s %s\n' "${api}" "${base}"
+           done
+         done 2>/dev/null | sort -n | head -n 1 | cut -d' ' -f2)
+  fi
+  if [ -z "${CC}" ] && command -v "${HOST}-gcc" >/dev/null 2>&1; then
+    CC="${HOST}-gcc"
+  fi
+  if [ -z "${CC}" ]; then
+    echo "Error: no cross compiler found for HOST=${HOST}." 1>&2
+    echo "Set CC, or API_LEVEL if your NDK uses a versioned clang name." 1>&2
     exit 1
   fi
+  export CC
 fi
 export AR="${AR:-${HOST}-ar}"
 export RANLIB="${RANLIB:-${HOST}-ranlib}"

--- a/build_for_android.sh
+++ b/build_for_android.sh
@@ -148,6 +148,23 @@ fi
 if [ "$(uname -s)" = "Darwin" ]; then
   PATH=/usr/local/opt/gettext/bin:${PATH} # brew install gettext
 fi
+
+# NDK llvm toolchains need an explicit cross compiler or configure picks the host.
+if [ -z "${CC}" ]; then
+  if command -v "${HOST}-clang" >/dev/null 2>&1; then
+    export CC="${HOST}-clang"
+  elif command -v "${HOST}21-clang" >/dev/null 2>&1; then
+    export CC="${HOST}21-clang"
+  elif command -v "${HOST}-gcc" >/dev/null 2>&1; then
+    export CC="${HOST}-gcc"
+  else
+    echo "Error: no cross compiler found for HOST=${HOST}" 1>&2
+    exit 1
+  fi
+fi
+export AR="${AR:-${HOST}-ar}"
+export RANLIB="${RANLIB:-${HOST}-ranlib}"
+
 LIBS="-lncurses -lm" ./configure --host="${HOST}" --prefix="${SYSROOT}/usr" \
     --enable-static --disable-shared
 [ "$?" != "0" ] && exit 1

--- a/common.c
+++ b/common.c
@@ -51,8 +51,9 @@ static enum pstate check_process(pid_t pid)
     int pr_len, path_len = sizeof("/proc/") - 1;
 
     /* append $pid/status and check if file exists */
-    pr_len = sprintf((path_str + path_len), "%d/status", pid);
-    if (pr_len <= 0)
+    pr_len = snprintf(path_str + path_len, sizeof(path_str) - path_len,
+                      "%d/status", pid);
+    if (pr_len <= 0 || (size_t)path_len + (size_t)pr_len >= sizeof(path_str))
         goto err;
     path_len += pr_len;
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([scanmem],[0.18.0],[https://github.com/scanmem/scanmem])
+AC_INIT([scanmem],[0.18~dev],[https://github.com/scanmem/scanmem])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([-Wall -Werror -Wno-extra-portability foreign])
 AC_CONFIG_SRCDIR([main.c])

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([scanmem],[0.18~dev],[https://github.com/scanmem/scanmem])
+AC_INIT([scanmem],[0.18.0],[https://github.com/scanmem/scanmem])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([-Wall -Werror -Wno-extra-portability foreign])
 AC_CONFIG_SRCDIR([main.c])

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     Game Conqueror: a graphical game cheating tool, using scanmem as its backend
     

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -46,6 +46,7 @@ import misc
 
 import locale
 import gettext
+import pwd
 
 # In some locale, ',' is used in float numbers
 locale.setlocale(locale.LC_NUMERIC, 'C')
@@ -116,6 +117,38 @@ TYPESIZES = {'int8':1
             ,'float32':4
             ,'float64':8
             }
+
+def _read_proc_cmdline(pid):
+    cmdline_path = os.path.join('/proc', str(pid), 'cmdline')
+    try:
+        with open(cmdline_path, 'rb') as fh:
+            raw = fh.read()
+    except OSError:
+        raw = b''
+    if raw:
+        return raw.replace(b'\0', b' ').decode('utf-8', 'replace').strip()
+    exelink = os.path.join('/proc', str(pid), 'exe')
+    if os.path.exists(exelink):
+        return os.path.realpath(exelink)
+    return ''
+
+
+def _read_proc_username(pid):
+    status_path = os.path.join('/proc', str(pid), 'status')
+    try:
+        with open(status_path, 'r', encoding='utf-8', errors='replace') as fh:
+            for line in fh:
+                if line.startswith('Uid:'):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        try:
+                            return pwd.getpwuid(int(parts[1])).pw_name
+                        except (KeyError, ValueError):
+                            return parts[1]
+    except OSError:
+        pass
+    return ''
+
 
 class GameConqueror():
     def __init__(self):
@@ -916,18 +949,14 @@ class GameConqueror():
 
     def get_process_list(self):
         plist = []
-        for proc in os.popen('ps -wweo pid=,user:16=,command= --sort=-pid').readlines():
-            try:
-                (pid, user, pname) = [tok.strip() for tok in proc.split(None, 2)]
-            # process name may be empty, but not the name of the executable
-            except (ValueError):
-                (pid, user) = [tok.strip() for tok in proc.split(None, 1)]
-                exelink = os.path.join("/proc", pid, "exe")
-                if os.path.exists(exelink):
-                    pname = os.path.realpath(exelink)
-                else:
-                    pname = ''
-            plist.append((int(pid), user, pname))
+        for entry in os.listdir('/proc'):
+            if not entry.isdigit():
+                continue
+            pid = int(entry)
+            user = _read_proc_username(pid)
+            pname = _read_proc_cmdline(pid)
+            plist.append((pid, user, pname))
+        plist.sort(key=lambda item: item[0], reverse=True)
         return plist
 
     def select_process(self, pid, process_name):
@@ -1210,11 +1239,7 @@ if __name__ == '__main__':
 
     # Attach to given pid (if any)
     if (args.pid is not None) :
-        process_name = os.popen('ps -p ' + str(args.pid) + ' -o command=').read().strip()
-        if process_name == '':
-            exelink = os.path.join("/proc", str(args.pid), "exe")
-            if os.path.exists(exelink):
-                process_name = os.path.realpath(exelink)
+        process_name = _read_proc_cmdline(args.pid)
         gc_instance.select_process(args.pid, process_name)
 
     # Prefill the search box (if asked)

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -1114,23 +1114,18 @@ class GameConqueror():
             self.scanresult_tv.set_model(None)
             # temporarily disable model for scanresult_liststore for the sake of performance
             self.scanresult_liststore.clear()
-            if misc.PY3K:
-                addr = GObject.Value(GObject.TYPE_UINT64)
-                off = GObject.Value(GObject.TYPE_UINT64)
+            addr = GObject.Value(GObject.TYPE_UINT64)
+            off = GObject.Value(GObject.TYPE_UINT64)
             for (mid_str, addr_str, off_str, rt, val, t) in matches:
                 if t == 'unknown':
                     continue
                 mid = int(mid_str)
                 # `insert_with_valuesv` has the same function of `append`, but it's 7x faster
-                # PY3 has problems with int's, so we need a forced guint64 conversion
+                # python3 has problems with int's, so we need a forced guint64 conversion
                 # See: https://bugzilla.gnome.org/show_bug.cgi?id=769532
                 # Still 5x faster even with the extra baggage
-                if misc.PY3K:
-                    addr.set_uint64(int(addr_str, 16))
-                    off.set_uint64(int(off_str, 16))
-                else:
-                    addr = long(addr_str, 16)
-                    off = long(off_str, 16)
+                addr.set_uint64(int(addr_str, 16))
+                off.set_uint64(int(off_str, 16))
                 self.scanresult_liststore.insert_with_valuesv(-1, [0, 1, 2, 3, 4, 5, 6], [addr, val, t, True, off, rt, mid])
                 # self.scanresult_liststore.append([addr, val, t, True, off, rt, mid])
             self.scanresult_tv.set_model(self.scanresult_liststore)

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -122,7 +122,7 @@ def _read_proc_cmdline(pid):
     cmdline_path = os.path.join('/proc', str(pid), 'cmdline')
     try:
         with open(cmdline_path, 'rb') as fh:
-            raw = fh.read()
+            raw = fh.read(4096)
     except OSError:
         raw = b''
     if raw:

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
     Game Conqueror: a graphical game cheating tool, using scanmem as its backend
     
@@ -141,6 +141,8 @@ class GameConqueror():
         self.memoryeditor_hexview.show_all()
         self.memoryeditor_address_entry = self.builder.get_object('MemoryEditor_Address_Entry')
         self.memoryeditor_hexview.connect('char-changed', self.memoryeditor_hexview_char_changed_cb)
+        self.editmemory_dialog = self.builder.get_object('EditMemoryDialog')
+        self.memoryeditor_value_type  = self.builder.get_object('DisplayType_ComboBoxText')
 
         self.found_count_label = self.builder.get_object('FoundCount_Label')
         self.process_label = self.builder.get_object('Process_Label')
@@ -333,6 +335,28 @@ class GameConqueror():
 
     # Memory editor
 
+    def MemoryEditor_EditView_cb(self, widget, data=None):
+        self.editmemory_dialog.show()
+
+    def CloseMemoryDialog_cb(self,widget,data=None):
+        self.editmemory_dialog.hide()
+
+    def SaveMemoryDialog_cb(self,widget,data=None):
+        txt = self.memoryeditor_value_type.get_active_text().strip()
+        self.memoryeditor_hexview.display_type = txt;
+        self.editmemory_dialog.hide()
+
+        dlength = len(self.memoryeditor_hexview.payload)
+        data = self.read_memory(self.memoryeditor_hexview.base_addr, dlength)
+        if data is None:
+            self.memoryeditor_window.hide()
+            self.show_error(_('Cannot read memory'))
+            return
+        old_addr = self.memoryeditor_hexview.get_current_addr()
+        self.memoryeditor_hexview.payload = misc.str2bytes(data)
+        self.memoryeditor_hexview.show_addr(old_addr)
+
+        
     def MemoryEditor_Button_clicked_cb(self, button, data=None):
         if self.pid == 0:
             self.show_error(_('Please select a process'))
@@ -570,7 +594,7 @@ class GameConqueror():
         self.memoryeditor_hexview.payload = misc.str2bytes(data)
         self.memoryeditor_hexview.show_addr(old_addr)
 
-
+    
     # Manually add cheat
 
     def focus_on_next_widget_cb(self, widget, data=None):

--- a/gui/GameConqueror.ui
+++ b/gui/GameConqueror.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 
+<!-- Generated with glade 3.40.0 
 
 Copyright (C) 2009,2010,2011,2013 Wang Lu <coolwanglu(a)gmail.com>
 Copyright (C) 2013 Mattias Muenster <mattiasmun(a)gmail.com>
@@ -30,82 +30,87 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
   <object class="GtkAdjustment" id="Length_SpinButton_Adjustment">
     <property name="lower">1</property>
     <property name="upper">1024</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="SearchScope_Scale_Adjustment">
     <property name="upper">3</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkImage" id="add_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">list-add</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">list-add</property>
   </object>
   <object class="GtkImage" id="delete_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">edit-delete</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-delete</property>
   </object>
   <object class="GtkImage" id="edit_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">gtk-edit</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">gtk-edit</property>
+  </object>
+  <object class="GtkImage" id="edit_image1">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">applications-system</property>
   </object>
   <object class="GtkImage" id="find_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">edit-find</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">edit-find</property>
   </object>
   <object class="GtkImage" id="jumpto_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">go-jump</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">go-jump</property>
   </object>
   <object class="GtkImage" id="load_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">document-open</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-open</property>
   </object>
   <object class="GtkImage" id="refresh_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">view-refresh</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">view-refresh</property>
   </object>
   <object class="GtkImage" id="refresh_image2">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="stock">gtk-refresh</property>
   </object>
   <object class="GtkWindow" id="MemoryEditor_Window">
-    <property name="height_request">280</property>
-    <property name="can_focus">False</property>
+    <property name="height-request">280</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">GameConqueror - Memory Editor</property>
     <property name="resizable">False</property>
     <property name="icon">GameConqueror_128x128.png</property>
-    <property name="type_hint">utility</property>
+    <property name="type-hint">utility</property>
     <signal name="delete-event" handler="hide_window_on_delete_event_cb" swapped="no"/>
     <signal name="key-press-event" handler="memoryeditor_key_press_event_cb" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox2">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="margin_top">5</property>
+        <property name="can-focus">False</property>
+        <property name="margin-top">5</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkBox" id="addressBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkLabel" id="addressLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
-                <property name="margin_right">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
+                <property name="margin-right">5</property>
                 <property name="label" translatable="yes">_Address:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">MemoryEditor_Address_Entry</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">MemoryEditor_Address_Entry</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -116,11 +121,11 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
             <child>
               <object class="GtkEntry" id="MemoryEditor_Address_Entry">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">Target address here (CTRL+L)</property>
-                <property name="margin_right">5</property>
-                <property name="activates_default">True</property>
-                <property name="placeholder_text" translatable="yes">Enter address to view</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">Target address here (CTRL+L)</property>
+                <property name="margin-right">5</property>
+                <property name="activates-default">True</property>
+                <property name="placeholder-text" translatable="yes">Enter address to view</property>
                 <signal name="activate" handler="MemoryEditor_Handle_Address_cb" swapped="no"/>
                 <accelerator key="l" signal="grab-focus" modifiers="GDK_CONTROL_MASK"/>
               </object>
@@ -132,14 +137,14 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
             </child>
             <child>
               <object class="GtkButton" id="MemoryEditor_JumpTo_Button">
-                <property name="width_request">28</property>
-                <property name="height_request">28</property>
+                <property name="width-request">28</property>
+                <property name="height-request">28</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Jump to address (CTRL+ENTER)</property>
-                <property name="margin_right">2</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Jump to address (CTRL+ENTER)</property>
+                <property name="margin-right">2</property>
                 <property name="image">jumpto_image</property>
                 <signal name="clicked" handler="MemoryEditor_Handle_Address_cb" swapped="no"/>
                 <accelerator key="Return" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -152,13 +157,13 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
             </child>
             <child>
               <object class="GtkButton" id="MemoryEditor_Refresh_Button">
-                <property name="width_request">28</property>
-                <property name="height_request">28</property>
+                <property name="width-request">28</property>
+                <property name="height-request">28</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">_Refresh (CTRL+R)</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">_Refresh (CTRL+R)</property>
                 <property name="image">refresh_image2</property>
                 <signal name="clicked" handler="MemoryEditor_Refresh_Button_clicked_cb" swapped="no"/>
                 <accelerator key="r" signal="activate" modifiers="GDK_CONTROL_MASK"/>
@@ -172,7 +177,7 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
             <child>
               <object class="GtkAlignment" id="alignment1">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <child>
                   <placeholder/>
                 </child>
@@ -181,6 +186,24 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="MemoryEditor_Edit">
+                <property name="width-request">32</property>
+                <property name="height-request">32</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Memory Editor (CTRL+SHIFT+M)</property>
+                <property name="image">edit_image1</property>
+                <signal name="clicked" handler="MemoryEditor_EditView_cb" swapped="no"/>
+                <accelerator key="m" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">6</property>
               </packing>
             </child>
           </object>
@@ -195,52 +218,52 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
   </object>
   <object class="GtkImage" id="save_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">document-save</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">document-save</property>
   </object>
   <object class="GtkImage" id="stop_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">stop</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">stop</property>
   </object>
   <object class="GtkImage" id="system_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">computer</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">computer</property>
   </object>
   <object class="GtkWindow" id="MainWindow">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">GameConqueror</property>
-    <property name="window_position">center</property>
-    <property name="default_width">550</property>
-    <property name="default_height">550</property>
+    <property name="window-position">center</property>
+    <property name="default-width">550</property>
+    <property name="default-height">550</property>
     <property name="icon">GameConqueror_128x128.png</property>
     <child>
       <object class="GtkPaned" id="vpaned1">
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
+        <property name="can-focus">True</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="GtkPaned" id="hpaned1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="position">200</property>
-            <property name="position_set">True</property>
+            <property name="position-set">True</property>
             <child>
               <object class="GtkBox" id="resultsBox">
-                <property name="width_request">200</property>
+                <property name="width-request">200</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkLabel" id="FoundCount_Label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="halign">start</property>
-                    <property name="margin_left">5</property>
-                    <property name="margin_top">2</property>
-                    <property name="margin_bottom">2</property>
+                    <property name="margin-left">5</property>
+                    <property name="margin-top">2</property>
+                    <property name="margin-bottom">2</property>
                     <property name="label" translatable="yes">Found: 0</property>
                   </object>
                   <packing>
@@ -252,12 +275,12 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
                 <child>
                   <object class="GtkScrolledWindow" id="scrolledwindow2">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <child>
                       <object class="GtkTreeView" id="ScanResult_TreeView">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="rubber_banding">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="rubber-banding">True</property>
                         <signal name="button-press-event" handler="ScanResult_TreeView_button_press_event_cb" swapped="no"/>
                         <signal name="key-press-event" handler="ScanResult_TreeView_key_press_event_cb" swapped="no"/>
                         <signal name="popup-menu" handler="ScanResult_TreeView_popup_menu_cb" swapped="no"/>
@@ -282,20 +305,22 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
               </packing>
             </child>
             <child>
+              <!-- n-columns=3 n-rows=4 -->
               <object class="GtkGrid" id="mainGrid">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="border_width">5</property>
-                <property name="row_spacing">5</property>
+                <property name="can-focus">False</property>
+                <property name="border-width">5</property>
+                <property name="row-spacing">5</property>
                 <child>
+                  <!-- n-columns=4 n-rows=3 -->
                   <object class="GtkGrid" id="searchGrid">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkLabel" id="helpLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_markup" translatable="yes">Syntax:
+                        <property name="can-focus">False</property>
+                        <property name="tooltip-markup" translatable="yes">Syntax:
 
  For numeric types:
 &lt;span font_family="monospace"&gt;
@@ -324,275 +349,347 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
 
  For string: enter the string directly</property>
                         <property name="label" translatable="yes">_Value: &lt;span color="blue"&gt;&lt;u&gt;?&lt;/u&gt;&lt;/span&gt;</property>
-                        <property name="use_markup">True</property>
-                        <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">Value_Input</property>
-                        <property name="single_line_mode">True</property>
+                        <property name="use-markup">True</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">Value_Input</property>
+                        <property name="single-line-mode">True</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="Value_Input">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Enter search value here (CTRL+K/L)</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Enter search value here (CTRL+K/L)</property>
+                        <property name="margin-left">5</property>
+                        <property name="margin-right">5</property>
                         <property name="hexpand">True</property>
-                        <property name="activates_default">True</property>
-                        <property name="placeholder_text" translatable="yes">Insert value to search for (CTRL+K/L)</property>
+                        <property name="activates-default">True</property>
+                        <property name="placeholder-text" translatable="yes">Insert value to search for (CTRL+K/L)</property>
                         <signal name="activate" handler="Value_Input_activate_cb" swapped="no"/>
                         <signal name="key-press-event" handler="value_input_key_press_event_cb" swapped="no"/>
                         <accelerator key="k" signal="grab-focus" modifiers="GDK_CONTROL_MASK"/>
                         <accelerator key="l" signal="grab-focus" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="Scan_Button">
-                        <property name="width_request">32</property>
-                        <property name="height_request">32</property>
+                        <property name="width-request">32</property>
+                        <property name="height-request">32</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="can_default">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Scan (CTRL+ENTER)</property>
-                        <property name="margin_right">1</property>
+                        <property name="can-focus">True</property>
+                        <property name="can-default">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Scan (CTRL+ENTER)</property>
+                        <property name="margin-right">1</property>
                         <property name="image">find_image</property>
                         <signal name="clicked" handler="Scan_Button_clicked_cb" swapped="no"/>
                         <accelerator key="Return" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">2</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="Reset_Button">
-                        <property name="width_request">32</property>
-                        <property name="height_request">32</property>
+                        <property name="width-request">32</property>
+                        <property name="height-request">32</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">Reset (CTRL+R)</property>
-                        <property name="margin_left">1</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">Reset (CTRL+R)</property>
+                        <property name="margin-left">1</property>
                         <property name="image">refresh_image</property>
                         <signal name="clicked" handler="Reset_Button_clicked_cb" swapped="no"/>
                         <accelerator key="r" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                       <packing>
-                        <property name="left_attach">3</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">3</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="Stop_Button">
-                        <property name="width_request">32</property>
-                        <property name="height_request">32</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Stop scan</property>
-                        <property name="margin_right">1</property>
+                        <property name="width-request">32</property>
+                        <property name="height-request">32</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Stop scan</property>
+                        <property name="margin-right">1</property>
                         <property name="image">stop_image</property>
                         <signal name="clicked" handler="Stop_Button_clicked_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">2</property>
+                        <property name="top-attach">0</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
                   </packing>
                 </child>
                 <child>
+                  <!-- n-columns=3 n-rows=3 -->
                   <object class="GtkGrid" id="headGrid">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="column_spacing">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="column-spacing">5</property>
                     <child>
                       <object class="GtkEventBox" id="Logo_EventBox">
-                        <property name="width_request">72</property>
-                        <property name="height_request">72</property>
+                        <property name="width-request">72</property>
+                        <property name="height-request">72</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">About</property>
-                        <property name="visible_window">False</property>
+                        <property name="can-focus">False</property>
+                        <property name="tooltip-text" translatable="yes">About</property>
+                        <property name="visible-window">False</property>
                         <signal name="button-release-event" handler="Logo_EventBox_button_release_event_cb" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="Logo_Image">
-                            <property name="width_request">72</property>
-                            <property name="height_request">72</property>
+                            <property name="width-request">72</property>
+                            <property name="height-request">72</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="pixbuf">GameConqueror_72x72.png</property>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                         <property name="height">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkProgressBar" id="ScanProgress_ProgressBar">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="valign">start</property>
-                        <property name="margin_top">5</property>
+                        <property name="margin-top">5</property>
                         <property name="hexpand">True</property>
-                        <property name="show_text">True</property>
+                        <property name="show-text">True</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
+                      <!-- n-columns=3 n-rows=3 -->
                       <object class="GtkGrid" id="processGrid">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <child>
                           <object class="GtkButton" id="SelectProcess_Button">
-                            <property name="width_request">32</property>
-                            <property name="height_request">32</property>
+                            <property name="width-request">32</property>
+                            <property name="height-request">32</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                            <property name="tooltip_text" translatable="yes">Select a process (CTRL+F)</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="tooltip-text" translatable="yes">Select a process (CTRL+F)</property>
                             <property name="image">system_image</property>
                             <signal name="clicked" handler="SelectProcess_Button_clicked_cb" swapped="no"/>
                             <accelerator key="f" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                           </object>
                           <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">0</property>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="Process_Label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">Select a process</property>
+                            <property name="can-focus">False</property>
+                            <property name="tooltip-text" translatable="yes">Select a process</property>
                             <property name="label" translatable="yes">No process selected</property>
                             <property name="ellipsize">end</property>
                           </object>
                           <packing>
-                            <property name="left_attach">1</property>
-                            <property name="top_attach">0</property>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">0</property>
                           </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
                         </child>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
                   <object class="GtkFrame" id="ScanOption_Frame">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">out</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">out</property>
                     <child>
                       <object class="GtkAlignment" id="alignment2">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="margin_left">10</property>
-                        <property name="margin_right">10</property>
-                        <property name="margin_bottom">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">10</property>
+                        <property name="margin-right">10</property>
+                        <property name="margin-bottom">5</property>
                         <child>
+                          <!-- n-columns=3 n-rows=3 -->
                           <object class="GtkGrid" id="frameInternalGrid">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="column_spacing">5</property>
+                            <property name="can-focus">False</property>
+                            <property name="column-spacing">5</property>
                             <child>
                               <object class="GtkComboBoxText" id="ScanDataType_ComboBoxText">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">0</property>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="dataLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Specify type of target data</property>
+                                <property name="can-focus">False</property>
+                                <property name="tooltip-text" translatable="yes">Specify type of target data</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Data _Type:</property>
-                                <property name="use_underline">True</property>
-                                <property name="mnemonic_widget">ScanDataType_ComboBoxText</property>
+                                <property name="use-underline">True</property>
+                                <property name="mnemonic-widget">ScanDataType_ComboBoxText</property>
                               </object>
                               <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">0</property>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">0</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkAlignment" id="alignment3">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="hexpand">True</property>
                                 <child>
                                   <placeholder/>
                                 </child>
                               </object>
                               <packing>
-                                <property name="left_attach">2</property>
-                                <property name="top_attach">0</property>
+                                <property name="left-attach">2</property>
+                                <property name="top-attach">0</property>
                                 <property name="height">2</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkLabel" id="searchLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_markup" translatable="yes">&lt;b&gt;Basic:&lt;/b&gt;      Fastest but may miss some values
+                                <property name="can-focus">False</property>
+                                <property name="tooltip-markup" translatable="yes">&lt;b&gt;Basic:&lt;/b&gt;      Fastest but may miss some values
 &lt;b&gt;Normal:&lt;/b&gt;  Works for most cases
 &lt;b&gt;Full:&lt;/b&gt;         Never miss values but slowest</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">_Search Scope:</property>
-                                <property name="use_underline">True</property>
-                                <property name="mnemonic_widget">SearchScope_Scale</property>
+                                <property name="use-underline">True</property>
+                                <property name="mnemonic-widget">SearchScope_Scale</property>
                               </object>
                               <packing>
-                                <property name="left_attach">0</property>
-                                <property name="top_attach">1</property>
+                                <property name="left-attach">0</property>
+                                <property name="top-attach">1</property>
                               </packing>
                             </child>
                             <child>
                               <object class="GtkScale" id="SearchScope_Scale">
-                                <property name="width_request">120</property>
+                                <property name="width-request">120</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="adjustment">SearchScope_Scale_Adjustment</property>
                                 <property name="digits">0</property>
-                                <property name="value_pos">bottom</property>
+                                <property name="value-pos">bottom</property>
                                 <signal name="format-value" handler="SearchScope_Scale_format_value_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="left_attach">1</property>
-                                <property name="top_attach">1</property>
+                                <property name="left-attach">1</property>
+                                <property name="top-attach">1</property>
                               </packing>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
+                            </child>
+                            <child>
+                              <placeholder/>
                             </child>
                           </object>
                         </child>
@@ -601,124 +698,185 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
                     <child type="label">
                       <object class="GtkLabel" id="buttonLabel">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                       </object>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">2</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
                   </packing>
                 </child>
                 <child>
+                  <!-- n-columns=6 n-rows=3 -->
                   <object class="GtkGrid" id="buttonGrid">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="column_spacing">2</property>
+                    <property name="can-focus">False</property>
+                    <property name="column-spacing">2</property>
                     <child>
                       <object class="GtkButton" id="MemoryEditor_Button">
-                        <property name="width_request">32</property>
-                        <property name="height_request">32</property>
+                        <property name="width-request">32</property>
+                        <property name="height-request">32</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Memory Editor (CTRL+SHIFT+M)</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Memory Editor (CTRL+SHIFT+M)</property>
                         <property name="image">edit_image</property>
                         <signal name="clicked" handler="MemoryEditor_Button_clicked_cb" swapped="no"/>
                         <accelerator key="m" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                       </object>
                       <packing>
-                        <property name="left_attach">5</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">5</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="SaveCheat_Button">
-                        <property name="width_request">32</property>
-                        <property name="height_request">32</property>
+                        <property name="width-request">32</property>
+                        <property name="height-request">32</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Save address list to file (CTRL+S)</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Save address list to file (CTRL+S)</property>
                         <property name="image">save_image</property>
                         <signal name="clicked" handler="SaveCheat_Button_clicked_cb" swapped="no"/>
                         <accelerator key="s" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                       <packing>
-                        <property name="left_attach">3</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">3</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="LoadCheat_Button">
-                        <property name="width_request">32</property>
-                        <property name="height_request">32</property>
+                        <property name="width-request">32</property>
+                        <property name="height-request">32</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Load address list from file (CTRL+O)</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Load address list from file (CTRL+O)</property>
                         <property name="image">load_image</property>
                         <signal name="clicked" handler="LoadCheat_Button_clicked_cb" swapped="no"/>
                         <accelerator key="o" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                       <packing>
-                        <property name="left_attach">2</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">2</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="RemoveAllCheat_Button">
-                        <property name="width_request">32</property>
-                        <property name="height_request">32</property>
+                        <property name="width-request">32</property>
+                        <property name="height-request">32</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Remove all entries (CTRL+D)</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Remove all entries (CTRL+D)</property>
                         <property name="image">delete_image</property>
                         <signal name="clicked" handler="RemoveAllCheat_Button_clicked_cb" swapped="no"/>
                         <accelerator key="d" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="ManuallyAddCheat_Button">
-                        <property name="width_request">32</property>
-                        <property name="height_request">32</property>
+                        <property name="width-request">32</property>
+                        <property name="height-request">32</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Manually add an entry (CTRL+M)</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Manually add an entry (CTRL+M)</property>
                         <property name="image">add_image</property>
                         <signal name="clicked" handler="ManuallyAddCheat_Button_clicked_cb" swapped="no"/>
                         <accelerator key="m" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkAlignment" id="alignment4">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <child>
                           <placeholder/>
                         </child>
                       </object>
                       <packing>
-                        <property name="left_attach">4</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">4</property>
+                        <property name="top-attach">0</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                   <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">3</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">3</property>
                   </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -735,12 +893,12 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
         <child>
           <object class="GtkScrolledWindow" id="scrolledwindow3">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="min_content_height">50</property>
+            <property name="can-focus">True</property>
+            <property name="min-content-height">50</property>
             <child>
               <object class="GtkTreeView" id="CheatList_TreeView">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="reorderable">True</property>
                 <signal name="button-press-event" handler="CheatList_TreeView_button_press_event_cb" swapped="no"/>
                 <signal name="key-press-event" handler="CheatList_TreeView_key_press_event_cb" swapped="no"/>
@@ -762,11 +920,11 @@ along with GameConqueror.  If not, see <http://www.gnu.org/licenses/>.
     </child>
   </object>
   <object class="GtkAboutDialog" id="AboutDialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="type_hint">dialog</property>
-    <property name="transient_for">MainWindow</property>
-    <property name="program_name">GameConqueror</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
+    <property name="type-hint">dialog</property>
+    <property name="transient-for">MainWindow</property>
+    <property name="program-name">GameConqueror</property>
     <property name="copyright" translatable="yes">Copyright (C) 2009-2014 WANG Lu  &lt;coolwanglu@gmail.com&gt;
 Copyright (C) 2010 Bryan Cain
 Copyright (C) 2015-2016 Sebastian Parschauer  &lt;s.parschauer@gmx.de&gt;
@@ -775,25 +933,25 @@ Copyright (C) 2016 Andrea Stacchiotti &lt;andreastacchiotti(a)gmail.com&gt;
 Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
     <property name="comments" translatable="yes">A graphical frontend of scanmem</property>
     <property name="website">https://github.com/scanmem/scanmem</property>
-    <property name="website_label" translatable="yes">Homepage</property>
+    <property name="website-label" translatable="yes">Homepage</property>
     <property name="authors">Wang Lu &lt;coolwanglu(a)gmail.com&gt;</property>
     <property name="logo">GameConqueror_128x128.png</property>
-    <property name="license_type">gpl-3-0</property>
+    <property name="license-type">gpl-3-0</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -805,33 +963,33 @@ Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
     <accelerator key="w" signal="close" modifiers="GDK_CONTROL_MASK"/>
   </object>
   <object class="GtkDialog" id="AddCheatDialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
     <property name="title" translatable="yes">Manually add an entry</property>
     <property name="resizable">False</property>
     <property name="modal">True</property>
     <property name="icon">GameConqueror_128x128.png</property>
-    <property name="type_hint">dialog</property>
-    <property name="transient_for">MainWindow</property>
+    <property name="type-hint">dialog</property>
+    <property name="transient-for">MainWindow</property>
     <signal name="delete-event" handler="hide_window_on_delete_event_cb" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">5</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area3">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <object class="GtkButton" id="ConfirmAddCheat_Button">
                 <property name="label" translatable="yes">_Add</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-underline">True</property>
                 <signal name="clicked" handler="ConfirmAddCheat_Button_clicked_cb" swapped="no"/>
               </object>
               <packing>
@@ -844,9 +1002,9 @@ Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
               <object class="GtkButton" id="CloseAddCheat_Button">
                 <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-underline">True</property>
                 <signal name="clicked" handler="CloseAddCheat_Button_clicked_cb" swapped="no"/>
               </object>
               <packing>
@@ -859,120 +1017,133 @@ Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
+          <!-- n-columns=3 n-rows=4 -->
           <object class="GtkGrid" id="addValueGrid">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="row_spacing">2</property>
-            <property name="column_spacing">5</property>
+            <property name="can-focus">False</property>
+            <property name="row-spacing">2</property>
+            <property name="column-spacing">5</property>
             <child>
               <object class="GtkLabel" id="Address_Label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Memory address of the value</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Memory address of the value</property>
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">Addres_s:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">Address_Input</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">Address_Input</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="Description_Label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Give a brief description of the value</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Give a brief description of the value</property>
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">_Description:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">Description_Input</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">Description_Input</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="Type_Label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Specify type of target data</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Specify type of target data</property>
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">_Type:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">Type_ComboBoxText</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">Type_ComboBoxText</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="Address_Input">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <signal name="activate" handler="focus_on_next_widget_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="Description_Input">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <signal name="activate" handler="focus_on_next_widget_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBoxText" id="Type_ComboBoxText">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <signal name="changed" handler="Type_ComboBoxText_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="Length_Label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Specify data length (string/bytearray only)</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Specify data length (string/bytearray only)</property>
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">_Length:</property>
-                <property name="use_underline">True</property>
-                <property name="mnemonic_widget">Length_SpinButton</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">Length_SpinButton</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">3</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkSpinButton" id="Length_SpinButton">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="activates_default">True</property>
+                <property name="can-focus">True</property>
+                <property name="activates-default">True</property>
                 <property name="adjustment">Length_SpinButton_Adjustment</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">3</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">3</property>
               </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
             </child>
           </object>
           <packing>
@@ -989,36 +1160,35 @@ Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
     </action-widgets>
     <accelerator key="w" signal="close" modifiers="GDK_CONTROL_MASK"/>
   </object>
-  <object class="GtkDialog" id="ProcessListDialog">
-    <property name="can_focus">False</property>
-    <property name="border_width">5</property>
-    <property name="title" translatable="yes">Type to search for a process</property>
+  <object class="GtkDialog" id="EditMemoryDialog">
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
+    <property name="title" translatable="yes">Memory editor configuration</property>
+    <property name="resizable">False</property>
     <property name="modal">True</property>
-    <property name="default_width">400</property>
-    <property name="default_height">500</property>
     <property name="icon">GameConqueror_128x128.png</property>
-    <property name="type_hint">dialog</property>
-    <property name="transient_for">MainWindow</property>
+    <property name="type-hint">dialog</property>
+    <property name="transient-for">MainWindow</property>
     <child internal-child="vbox">
-      <object class="GtkBox" id="dialog-vbox2">
+      <object class="GtkBox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="orientation">vertical</property>
-        <property name="spacing">5</property>
+        <property name="spacing">10</property>
         <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area2">
+          <object class="GtkButtonBox">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="baseline-position">bottom</property>
+            <property name="layout-style">end</property>
             <child>
-              <object class="GtkButton" id="ProcessListDialog_OK_Button">
-                <property name="label" translatable="yes">_OK</property>
+              <object class="GtkButton" id="EditMemorySaveButton">
+                <property name="label" translatable="yes">_Save</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="can_default">True</property>
-                <property name="has_default">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-underline">True</property>
+                <signal name="clicked" handler="SaveMemoryDialog_cb" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -1027,12 +1197,13 @@ Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
               </packing>
             </child>
             <child>
-              <object class="GtkButton" id="ProcessListDialog_Cancel_Button">
-                <property name="label" translatable="yes">_Cancel</property>
+              <object class="GtkButton" id="EditMemoryCloseButton">
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_underline">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-underline">True</property>
+                <signal name="clicked" handler="CloseMemoryDialog_cb" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -1044,78 +1215,214 @@ Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <!-- n-columns=2 n-rows=2 -->
+          <object class="GtkGrid" id="addValueGrid1">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="row-spacing">2</property>
+            <property name="column-spacing">10</property>
+            <child>
+              <object class="GtkComboBoxText" id="DisplayType_ComboBoxText">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="active">0</property>
+                <items>
+                  <item translatable="yes">byte</item>
+                  <item translatable="yes">float32</item>
+                  <item translatable="yes">float64</item>
+                  <item translatable="yes">int32</item>
+                  <item translatable="yes">int64</item>
+                </items>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="Address_Label1">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Memory address of the value</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">Display:</property>
+                <property name="use-underline">True</property>
+                <property name="mnemonic-widget">Address_Input</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="0">EditMemorySaveButton</action-widget>
+      <action-widget response="0">EditMemoryCloseButton</action-widget>
+    </action-widgets>
+    <accelerator key="w" signal="close" modifiers="GDK_CONTROL_MASK"/>
+  </object>
+  <object class="GtkDialog" id="ProcessListDialog">
+    <property name="can-focus">False</property>
+    <property name="border-width">5</property>
+    <property name="title" translatable="yes">Type to search for a process</property>
+    <property name="modal">True</property>
+    <property name="default-width">400</property>
+    <property name="default-height">500</property>
+    <property name="icon">GameConqueror_128x128.png</property>
+    <property name="type-hint">dialog</property>
+    <property name="transient-for">MainWindow</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox2">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">5</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="ProcessListDialog_OK_Button">
+                <property name="label" translatable="yes">_OK</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="has-default">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="ProcessListDialog_Cancel_Button">
+                <property name="label" translatable="yes">_Cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack-type">end</property>
             <property name="position">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkFrame" id="filterFrame">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="label_xalign">0</property>
-            <property name="shadow_type">in</property>
+            <property name="can-focus">False</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">in</property>
             <child>
               <object class="GtkAlignment" id="alignment5">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">10</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">10</property>
                 <child>
+                  <!-- n-columns=3 n-rows=3 -->
                   <object class="GtkGrid" id="filterGrid">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="margin_bottom">5</property>
-                    <property name="column_spacing">5</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-bottom">5</property>
+                    <property name="column-spacing">5</property>
                     <child>
                       <object class="GtkEntry" id="ProcessFilter_Input">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="activates_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="activates-default">True</property>
                         <signal name="changed" handler="ProcessFilter_Input_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkEntry" id="UserFilter_Input">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="activates_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="activates-default">True</property>
                         <signal name="changed" handler="UserFilter_Input_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label17">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">_User:</property>
-                        <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">UserFilter_Input</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">UserFilter_Input</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label16">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">_Process:</property>
-                        <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">ProcessFilter_Input</property>
+                        <property name="use-underline">True</property>
+                        <property name="mnemonic-widget">ProcessFilter_Input</property>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
                       </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
                     </child>
                   </object>
                 </child>
@@ -1124,9 +1431,9 @@ Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
             <child type="label">
               <object class="GtkLabel" id="filterLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Filter</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
               </object>
             </child>
           </object>
@@ -1139,11 +1446,11 @@ Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe</property>
         <child>
           <object class="GtkScrolledWindow" id="scrolledwindow1">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <child>
               <object class="GtkTreeView" id="ProcessList_TreeView">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <signal name="row-activated" handler="ProcessList_TreeView_row_activated_cb" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection" id="ProcessList_TreeSelection"/>

--- a/gui/gameconqueror.in
+++ b/gui/gameconqueror.in
@@ -2,9 +2,15 @@
 
 DATADIR=@PKGDATADIR@
 
-PKEXEC=$(command -v "pkexec")
+PYTHON3=$(command -v python3)
+if [ -z "$PYTHON3" ]; then
+    echo "python3 not found in PATH" 1>&2
+    exit 1
+fi
+
+PKEXEC=$(command -v pkexec)
 if [ -n "$PKEXEC" ]; then
-    $PKEXEC $DATADIR/GameConqueror.py "$@"
+    $PKEXEC "$PYTHON3" "$DATADIR/GameConqueror.py" "$@"
 else
     echo "install policykit!"
 fi

--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -25,8 +25,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import gi
-gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Pango
 from gi.repository import GObject
@@ -424,16 +422,40 @@ class HexText(BaseText):
 
         output = []
         convert = lambda x: '%02X'%(x,)
+        # hex view 
+
+        invert_hex = lambda d : ''.join([d[i:i+2] for i in range(0, len(d), 2)][::-1]) # convert "0xabcdefgh" to "0xghefcdab" 
+
+        # using python built-in library library "struct" to convert a hex to floats
+        convert_float32 = lambda a: str(__import__("struct").unpack('>f', int(a,16).to_bytes(4, 'big'))[0])[:11].rjust(11)
+        convert_float64 = lambda a: str(__import__("struct").unpack('>d', int(a,16).to_bytes(8, 'big'))[0])[:23].rjust(23)
+        convert_int32 = lambda a: str(int(a,16))[:11].rjust(11) 
+        convert_int64 = lambda a: str(int(a,16))[:23].rjust(23) 
 
         for i in range(tot_lines):
+            d1 = "".join(map(convert, txt[i * bpl:]))
+            d2 = "".join(map(convert, txt[i * bpl:(i * bpl) + bpl]))
+            if self._parent.display_type == "byte": 
+                # we split by space because the convert lambda will return byte array and we can just display it without modifications 
+                d1 = " ".join(map(convert, txt[i * bpl:])) 
+                d2 = " ".join(map(convert, txt[i * bpl:(i * bpl) + bpl]))
+            if self._parent.display_type== "float32": # convert byte to f32
+                d1 = " ".join([convert_float32(invert_hex(d1[i:i+8])) for i in range(0, len(d1), 8)])
+                d2 = " ".join([convert_float32(invert_hex(d2[i:i+8])) for i in range(0, len(d2), 8)])
+            if self._parent.display_type == "float64": # convert byte to f64
+                d1 = " ".join([convert_float64(invert_hex(d1[i:i+16])) for i in range(0, len(d1), 16)])
+                d2 = " ".join([convert_float64(invert_hex(d2[i:i+16])) for i in range(0, len(d2), 16)])
+            if self._parent.display_type == "int32":
+                d1 = ' '.join([convert_int32(invert_hex(d1[i:i+8])) for i in range(0, len(d1), 8)])
+                d2 = ' '.join([convert_int32(invert_hex(d2[i:i+8])) for i in range(0, len(d2), 8)])
+            if self._parent.display_type == "int64":
+                d1 = ' '.join([convert_int64(invert_hex(d1[i:i+16])) for i in range(0, len(d1), 16)])
+                d2 = ' '.join([convert_int64(invert_hex(d2[i:i+16])) for i in range(0, len(d2), 16)])
+
             if i * bpl + bpl > len(txt):
-                output.append(
-                    " ".join(map(convert, txt[i * bpl:]))
-                )
+                output.append(d1)
             else:
-                output.append(
-                    " ".join(map(convert, txt[i * bpl:(i * bpl) + bpl]))
-                )
+                output.append(d2)                  
 
         if output:
             self.buffer.insert_with_tags(
@@ -514,6 +536,8 @@ class HexView(Gtk.Box):
         self._payload = ""
         self._base_addr = 0;
         self.editable = False
+
+        self.display_type = "byte" 
 
         self.vadj = Gtk.Adjustment()
         self.vscroll = Gtk.Scrollbar.new(Gtk.Orientation.VERTICAL, self.vadj)

--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -25,6 +25,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Pango
 from gi.repository import GObject

--- a/gui/misc.py
+++ b/gui/misc.py
@@ -19,13 +19,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import sys
-
 import gi
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
-
-PY3K = sys.version_info >= (3, 0)
 
 # check command syntax, data range etc.
 # return a valid scanmem command
@@ -97,8 +93,7 @@ def check_scan_command (data_type, cmd, is_first_scan):
 def eval_operand(s):
     try:
         v = eval(s)
-        py2_long = not PY3K and isinstance(v, long)
-        if isinstance(v, int) or isinstance(v, float) or py2_long:
+        if isinstance(v, (int, float)):
             return v
     except:
         pass
@@ -109,8 +104,7 @@ def eval_operand(s):
 # raise an exception if not
 def check_int (data_type, num):
     if data_type.startswith('int'):
-        py2_long = not PY3K and isinstance(num, long)
-        if not (isinstance(num, int) or py2_long):
+        if not isinstance(num, int):
             raise ValueError(_('%s is not an integer') % (num,))
         if data_type == 'int':
             width = 64
@@ -200,24 +194,14 @@ def menu_append_item(menu, name, callback, data=None):
     menu.append(item)
     item.connect('activate', callback, data)
 
-# Interface for bytes<>string conversion for py2/3
-# Usage is the same you'd do in py3, call `decode` on external raw data
-# and `encode` to work with the memory representation
+# Call `decode` on external raw data and `encode` to work with the
+# memory representation
 def decode(raw_bytes, errors='strict'):
-    if PY3K:
-        return raw_bytes.decode(errors=errors)
-    else:
-        return str(raw_bytes)
+    return raw_bytes.decode(errors=errors)
 
 def encode(unicode_string, errors='strict'):
-    if PY3K:
-        return unicode_string.encode(errors=errors)
-    else:
-        return unicode_string
+    return unicode_string.encode(errors=errors)
 
 # Convert codepoints to integers byte by byte
 def str2bytes(string):
-    if PY3K:
-        return bytes(string)
-    else:
-        return map(ord, string)
+    return bytes(string)

--- a/gui/misc.py
+++ b/gui/misc.py
@@ -21,6 +21,8 @@
 
 import sys
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 PY3K = sys.version_info >= (3, 0)

--- a/handlers.c
+++ b/handlers.c
@@ -90,9 +90,9 @@
 
 bool handler__set(globals_t * vars, char **argv, unsigned argc)
 {
-    unsigned block, seconds = 1;
+    unsigned block, seconds;
     char *delay = NULL;
-    bool cont = false;
+    bool cont;
     struct setting {
         char *matchids;
         char *value;
@@ -128,6 +128,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
     settings = calloca(argc - 1, sizeof(struct setting));
 
     /* parse every block into a settings struct */
+    cont = false;
     for (block = 0; block < argc - 1; block++) {
 
         /* first separate the block into matches and value, which are separated by '=' */
@@ -194,6 +195,7 @@ bool handler__set(globals_t * vars, char **argv, unsigned argc)
 
     /* --- execute the parsed setting structs --- */
 
+    seconds = 1;
     while (true) {
         uservalue_t userval;
 

--- a/handlers.c
+++ b/handlers.c
@@ -46,6 +46,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <ctype.h>
+#include <sys/wait.h>
 
 #include "common.h"
 #include "commands.h"
@@ -87,6 +88,26 @@
 #else
 #define POINTER_FMT "%12lx"
 #endif
+
+static bool append_suffix(char **buf, size_t *buf_len, const char *suffix)
+{
+    size_t used = strlen(*buf);
+    size_t suffix_len = strlen(suffix);
+    size_t need = used + suffix_len + 1;
+
+    if (need > *buf_len) {
+        char *grown = realloc(*buf, need);
+
+        if (grown == NULL)
+            return false;
+
+        *buf = grown;
+        *buf_len = need;
+    }
+
+    memcpy((*buf) + used, suffix, suffix_len + 1);
+    return true;
+}
 
 bool handler__set(globals_t * vars, char **argv, unsigned argc)
 {
@@ -394,8 +415,11 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
                     goto fail;
                 }
                 data_to_bytearray_text(v, buf_len, reading_swath_index, reading_iterator, flags);
-                assert(strlen(v) + strlen(bytearray_suffix) + 1 <= buf_len); /* or maybe realloc is better? */
-                strcat(v, bytearray_suffix);
+                if (!append_suffix(&v, &buf_len, bytearray_suffix))
+                {
+                    show_error("memory allocation failed.\n");
+                    goto fail;
+                }
                 break;
             case STRING:
                 buf_len = flags + strlen(string_suffix) + 32; /* for the string and suffix, this should be enough */
@@ -406,8 +430,11 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
                     goto fail;
                 }
                 data_to_printable_string(v, buf_len, reading_swath_index, reading_iterator, flags);
-                assert(strlen(v) + strlen(string_suffix) + 1 <= buf_len); /* or maybe realloc is better? */
-                strcat(v, string_suffix);
+                if (!append_suffix(&v, &buf_len, string_suffix))
+                {
+                    show_error("memory allocation failed.\n");
+                    goto fail;
+                }
                 break;
             default: /* numbers */
                 ; /* cheat gcc */
@@ -844,7 +871,8 @@ bool handler__string(globals_t * vars, char **argv, unsigned argc)
         show_error("memory allocation for string failed.\n");
         return false;
     }
-    strcpy(string_value, vars->current_cmdline+2);
+    memcpy(string_value, vars->current_cmdline + 2, string_length);
+    string_value[string_length] = '\0';
 
     uservalue_t val;
     val.string_value = string_value;
@@ -1118,9 +1146,8 @@ bool handler__eof(globals_t * vars, char **argv, unsigned argc)
 /* XXX: handle !ls style escapes */
 bool handler__shell(globals_t * vars, char **argv, unsigned argc)
 {
-    size_t len = argc;
-    unsigned i;
-    char *command;
+    pid_t child;
+    int status;
 
     USEPARAMS();
 
@@ -1129,29 +1156,25 @@ bool handler__shell(globals_t * vars, char **argv, unsigned argc)
         return false;
     }
 
-    /* convert arg vector into single string, first calculate length */
-    for (i = 1; i < argc; i++)
-        len += strlen(argv[i]);
-
-    /* allocate space */
-    command = calloca(len, 1);
-
-    /* concatenate strings */
-    for (i = 1; i < argc; i++) {
-        strcat(command, argv[i]);
-        strcat(command, " ");
-    }
-
-    /* finally execute command */
-    if (system(command) == -1) {
-// command is allocated with alloca, do not free it
-//        free(command);
-        show_error("system() failed, command was not executed.\n");
+    child = fork();
+    if (child == -1) {
+        show_error("fork() failed, command was not executed.\n");
         return false;
     }
 
-// command is allocated with alloca, do not free it
-//    free(command);
+    if (child == 0) {
+        execvp(argv[1], argv + 1);
+        _exit(127);
+    }
+
+    if (waitpid(child, &status, 0) == -1) {
+        show_error("waitpid() failed after shell command.\n");
+        return false;
+    }
+
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+        return false;
+
     return true;
 }
 
@@ -1224,8 +1247,12 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
         /* check if the new value is different */
         match_flags tmpflags = flags_empty;
         if ((*valuecmp_routine)(memory_ptr, memlength, &val, NULL, &tmpflags)) {
+            size_t copy_len = memlength;
 
-            memcpy(val.bytes, memory_ptr, memlength);
+            if (copy_len > sizeof(val.bytes))
+                copy_len = sizeof(val.bytes);
+
+            memcpy(val.bytes, memory_ptr, copy_len);
 
             valtostr(&val, buf, sizeof(buf));
 
@@ -1613,7 +1640,8 @@ bool handler__write(globals_t * vars, char **argv, unsigned argc)
         free_uservalue(&val_buf);
         break;
     case 2: //string
-        strncpy(buf, string_parameter, data_width);
+        memcpy(buf, string_parameter, data_width);
+        buf[data_width] = '\0';
         break;
     default:
         assert(false);

--- a/handlers.c
+++ b/handlers.c
@@ -406,13 +406,18 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
             switch(vars->options.scan_data_type)
             {
             case BYTEARRAY:
-                buf_len = flags * 3 + 32;
-                v = realloc(v, buf_len); /* for each byte and the suffix, this should be enough */
-
-                if (v == NULL)
                 {
-                    show_error("memory allocation failed.\n");
-                    goto fail;
+                    char *grown;
+
+                    buf_len = flags * 3 + 32;
+                    grown = realloc(v, buf_len);
+
+                    if (grown == NULL)
+                    {
+                        show_error("memory allocation failed.\n");
+                        goto fail;
+                    }
+                    v = grown;
                 }
                 data_to_bytearray_text(v, buf_len, reading_swath_index, reading_iterator, flags);
                 if (!append_suffix(&v, &buf_len, bytearray_suffix))
@@ -422,12 +427,17 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
                 }
                 break;
             case STRING:
-                buf_len = flags + strlen(string_suffix) + 32; /* for the string and suffix, this should be enough */
-                v = realloc(v, buf_len);
-                if (v == NULL)
                 {
-                    show_error("memory allocation failed.\n");
-                    goto fail;
+                    char *grown;
+
+                    buf_len = flags + strlen(string_suffix) + 32;
+                    grown = realloc(v, buf_len);
+                    if (grown == NULL)
+                    {
+                        show_error("memory allocation failed.\n");
+                        goto fail;
+                    }
+                    v = grown;
                 }
                 data_to_printable_string(v, buf_len, reading_swath_index, reading_iterator, flags);
                 if (!append_suffix(&v, &buf_len, string_suffix))
@@ -1172,8 +1182,16 @@ bool handler__shell(globals_t * vars, char **argv, unsigned argc)
         return false;
     }
 
-    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+    if (!WIFEXITED(status)) {
+        show_error("shell command terminated abnormally.\n");
         return false;
+    }
+    if (WEXITSTATUS(status) == 127) {
+        show_error("execvp() failed, command was not executed.\n");
+        return false;
+    }
+    if (WEXITSTATUS(status) != 0)
+        show_warn("shell command exited with status %d.\n", WEXITSTATUS(status));
 
     return true;
 }

--- a/handlers.c
+++ b/handlers.c
@@ -46,7 +46,6 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <ctype.h>
-#include <sys/wait.h>
 
 #include "common.h"
 #include "commands.h"
@@ -1156,8 +1155,9 @@ bool handler__eof(globals_t * vars, char **argv, unsigned argc)
 /* XXX: handle !ls style escapes */
 bool handler__shell(globals_t * vars, char **argv, unsigned argc)
 {
-    pid_t child;
-    int status;
+    size_t len = argc;
+    unsigned i;
+    char *command;
 
     USEPARAMS();
 
@@ -1166,33 +1166,29 @@ bool handler__shell(globals_t * vars, char **argv, unsigned argc)
         return false;
     }
 
-    child = fork();
-    if (child == -1) {
-        show_error("fork() failed, command was not executed.\n");
+    /* convert arg vector into single string, first calculate length */
+    for (i = 1; i < argc; i++)
+        len += strlen(argv[i]);
+
+    /* allocate space */
+    command = calloca(len, 1);
+
+    /* concatenate strings */
+    for (i = 1; i < argc; i++) {
+        strcat(command, argv[i]);
+        strcat(command, " ");
+    }
+
+    /* finally execute command */
+    if (system(command) == -1) {
+// command is allocated with alloca, do not free it
+//        free(command);
+        show_error("system() failed, command was not executed.\n");
         return false;
     }
 
-    if (child == 0) {
-        execvp(argv[1], argv + 1);
-        _exit(127);
-    }
-
-    if (waitpid(child, &status, 0) == -1) {
-        show_error("waitpid() failed after shell command.\n");
-        return false;
-    }
-
-    if (!WIFEXITED(status)) {
-        show_error("shell command terminated abnormally.\n");
-        return false;
-    }
-    if (WEXITSTATUS(status) == 127) {
-        show_error("execvp() failed, command was not executed.\n");
-        return false;
-    }
-    if (WEXITSTATUS(status) != 0)
-        show_warn("shell command exited with status %d.\n", WEXITSTATUS(status));
-
+// command is allocated with alloca, do not free it
+//    free(command);
     return true;
 }
 

--- a/interrupt.c
+++ b/interrupt.c
@@ -29,7 +29,7 @@
 
 sigjmp_buf jmpbuf;       /* used when aborting a command due to an interrupt */
 sighandler_t oldsig;     /* reinstalled before longjmp */
-unsigned intr_used;
+volatile sig_atomic_t intr_used;
 
 /* signal handler used to handle an interrupt during commands */
 void interrupted(int n)

--- a/interrupt.h
+++ b/interrupt.h
@@ -29,7 +29,7 @@
 
 extern sigjmp_buf jmpbuf;       /* used when aborting a command due to an interrupt */
 extern sighandler_t oldsig;     /* reinstalled before longjmp */
-extern unsigned intr_used;
+extern volatile sig_atomic_t intr_used;
 
 /* signal handler used to handle an interrupt during commands */
 void interrupted(int);

--- a/maps.c
+++ b/maps.c
@@ -39,6 +39,9 @@
 #include "getline.h"
 #include "show_message.h"
 
+/* /proc maps pathnames are usually short; cap to avoid huge stack VLAs */
+#define MAPS_PATH_MAX 4096
+
 const char *region_type_names[] = REGION_TYPE_NAMES;
 
 bool sm_readmaps(pid_t target, list_t *regions, region_scan_level_t region_scan_level)
@@ -88,17 +91,17 @@ bool sm_readmaps(pid_t target, list_t *regions, region_scan_level_t region_scan_
         unsigned long start, end;
         region_t *map = NULL;
         char read, write, exec, cow;
-        int offset, dev_major, dev_minor, inode;
+        unsigned long offset, inode;
+        unsigned int dev_major, dev_minor;
         region_type_t type = REGION_TYPE_MISC;
 
-        /* slight overallocation */
-        char filename[len];
+        char filename[MAPS_PATH_MAX];
 
         /* initialise to zero */
-        memset(filename, '\0', len);
+        memset(filename, '\0', sizeof(filename));
 
         /* parse each line */
-        if (sscanf(line, "%lx-%lx %c%c%c%c %x %x:%x %u %[^\n]", &start, &end, &read,
+        if (sscanf(line, "%lx-%lx %c%c%c%c %lx %x:%x %lu %4095[^\n]", &start, &end, &read,
                 &write, &exec, &cow, &offset, &dev_major, &dev_minor, &inode, filename) >= 6) {
             /*
              * get the load address for regions of the same ELF file

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -2,5 +2,6 @@ de
 es
 it
 ja
+ka
 ru
 sr_ME

--- a/po/ka.po
+++ b/po/ka.po
@@ -1,0 +1,541 @@
+# Georgian translation for scanmem.
+# Copyright (C) 2023, scanmem's authors
+# This file is distributed under the same license as the scanmem package.
+# Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-02-17 15:26+0100\n"
+"PO-Revision-Date: 2023-02-18 10:52+0100\n"
+"Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>\n"
+"Language-Team: \n"
+"Language: ka\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: ../gui/GameConqueror.ui.h:1
+msgid "GameConqueror - Memory Editor"
+msgstr "GameConqueror - მეხსიერების რედაქტორი"
+
+#: ../gui/GameConqueror.ui.h:2
+msgid "_Address:"
+msgstr "მის_ამართი:"
+
+#: ../gui/GameConqueror.ui.h:3
+msgid "Target address here (CTRL+L)"
+msgstr "სამიზნე მისამართი აქ (CTRL+L)"
+
+#: ../gui/GameConqueror.ui.h:4
+msgid "Enter address to view"
+msgstr "შეიყვანეთ მისამართი სანახავად"
+
+#: ../gui/GameConqueror.ui.h:5
+msgid "Jump to address (CTRL+ENTER)"
+msgstr "გადასვლა მისამართზე (CTRL+ ENTER)"
+
+#: ../gui/GameConqueror.ui.h:6
+msgid "_Refresh (CTRL+R)"
+msgstr "_განახლება (CTRL+R)"
+
+#: ../gui/GameConqueror.ui.h:7
+msgid "GameConqueror"
+msgstr "GameConqueror"
+
+#: ../gui/GameConqueror.ui.h:8
+msgid "Found: 0"
+msgstr "მოიძებნა: 0"
+
+#: ../gui/GameConqueror.ui.h:9
+msgid ""
+"Syntax:\n"
+"\n"
+" For numeric types:\n"
+"<span font_family=\"monospace\">\n"
+" <b>N</b>         Exactly this number\n"
+" <b>N..M</b>      Range between two numbers\n"
+" <b>?</b>         Unknown initial value\n"
+" <b>&gt; or +</b>    Increased values\n"
+" <b>&lt; or -</b>    Decreased values\n"
+" <b>=</b>         Unchanged values\n"
+" <b>!=</b>        Changed values\n"
+" <b>&gt; N</b>       Greater than N\n"
+" <b>&lt; N</b>       Less than N\n"
+" <b>+ N</b>       Increased by N\n"
+" <b>- N</b>       Decreased by N\n"
+" <b>!= N</b>      Other than N\n"
+"</span>\n"
+" where N could be a number of a simple math expression embraced by (), e."
+"g.\n"
+"<span font_family=\"monospace\"> 12\n"
+" 0x34\n"
+" 5.67\n"
+" (- 8 * 9)</span>\n"
+"\n"
+" For bytearray: use 2-char hexadecimal notation for each byte, separated by "
+"spaces\n"
+" e.g. <span font_family=\"monospace\">FE DC BA 98 76 54 32 10</span>\n"
+" <span font_family=\"monospace\">??</span> can be used as a wildcard value\n"
+"\n"
+" For string: enter the string directly"
+msgstr ""
+"სინტაქსი:\n"
+"\n"
+"რიცხვითი ტიპებისთვის:\n"
+"<span font_family=\"monospace\">\n"
+" <b>N</b>         ზუსტად ეს რიცხვი\n"
+" <b>ნ.. M</b>      დიაპაზონი ორ რიცხვს შორის\n"
+" <b>?</b>         უცნობი საწყისი ღირებულება\n"
+" <b>&gt; ან +</b>    გაზრდილი ღირებულებები\n"
+" <b>&lt; ან -</b>    შემცირებული ღირებულებები\n"
+" <b>=</b>         უცვლელი ღირებულებები\n"
+" <b>!=</b>        შეცვლილი ღირებულებები\n"
+" <b>&gt; N</b>       უფრო დიდი ვიდრე N\n"
+" <b>&lt; N</b>       N-ზე ნაკლები\n"
+" <b>+ N</b>       გაიზარდა N- ით\n"
+" <b>- N</b>       N-ით შემცირდა\n"
+" <b>!= N</b>      N-ის გარდა\n"
+"</span>\n"
+" სადაც N შეიძლება იყოს მრავალი მარტივი მათემატიკის გამოხატულება, რომელიც "
+"მიღებულია (), მაგალითად.\n"
+"<span font_family=\"monospace\"> 12\n"
+" 0x34\n"
+" 5.67\n"
+" (- 8 * 9)</span>\n"
+"\n"
+"bytearray: გამოიყენეთ 2-char hexadecimal ნოტაცია თითოეული byte, გამოყოფილი "
+"სივრცეები\n"
+" მაგ. <span font_family=\"monospace\">FE DC BA 98 76 54 32 10</span>\n"
+" <span font_family=\"monospace\">??</span> \n"
+"\n"
+"სტრიქონისთვის: პირდაპირ შეიყვანეთ სტრიქონი"
+
+#: ../gui/GameConqueror.ui.h:37
+msgid "_Value: <span color=\"blue\"><u>?</u></span>"
+msgstr "_მნიშვნელობა: <span color=\"blue\"><u>?</u></span>"
+
+#: ../gui/GameConqueror.ui.h:38
+msgid "Enter search value here (CTRL+K/L)"
+msgstr "შეიყვანეთ საძებნი მნიშვნელობა აქ (CTRL + K/ L)"
+
+#: ../gui/GameConqueror.ui.h:39
+msgid "Insert value to search for (CTRL+K/L)"
+msgstr "მნიშვნელობა მოსაძებნად (CTRL + K/L)"
+
+#: ../gui/GameConqueror.ui.h:40
+msgid "Scan (CTRL+ENTER)"
+msgstr "სკანირება (CTRL+ ENTER)"
+
+#: ../gui/GameConqueror.ui.h:41
+msgid "Reset (CTRL+R)"
+msgstr "გადატვირთვა (CTRL+R)"
+
+#: ../gui/GameConqueror.ui.h:42
+msgid "Stop scan"
+msgstr "ძებნის შეჩერება"
+
+#: ../gui/GameConqueror.ui.h:43
+msgid "About"
+msgstr "პროგრამის შესახებ"
+
+#: ../gui/GameConqueror.ui.h:44
+msgid "Select a process (CTRL+F)"
+msgstr "აირჩიეთ პროცესი (CTRL+F)"
+
+#: ../gui/GameConqueror.ui.h:45 ../gui/GameConqueror.py:920
+msgid "Select a process"
+msgstr "აირჩიეთ პროცესი"
+
+#: ../gui/GameConqueror.ui.h:46 ../gui/GameConqueror.py:919
+msgid "No process selected"
+msgstr "პროცესი არჩეული არაა"
+
+#: ../gui/GameConqueror.ui.h:47
+msgid "Specify type of target data"
+msgstr "მიუთითეთ სამიზნე მონაცემების ტიპი"
+
+#: ../gui/GameConqueror.ui.h:48
+msgid "Data _Type:"
+msgstr "მონაცემების _ტიპი:"
+
+#: ../gui/GameConqueror.ui.h:49
+msgid ""
+"<b>Basic:</b>      Fastest but may miss some values\n"
+"<b>Normal:</b>  Works for most cases\n"
+"<b>Full:</b>         Never miss values but slowest"
+msgstr ""
+"<b>ძირითადი:</b>      ყველაზე სწრაფი, მაგრამ შეიძლება გამოტოვოს რამდენიმე "
+"მნიშვნელობა\n"
+"<b>ნორმალური:</b>  მუშაობს უმეტეს შემთხვევაში\n"
+"<b>სრული:</b>         არასოდეს გამოტოვებს მნიშვნელობებს, მაგრამ ნელია"
+
+#: ../gui/GameConqueror.ui.h:52
+msgid "_Search Scope:"
+msgstr "_ძებნის დიაპაზონი:"
+
+#: ../gui/GameConqueror.ui.h:53
+msgid "Memory Editor (CTRL+SHIFT+M)"
+msgstr "მეხსიერების რედაქტორი (CTRL+SHIFT+M)"
+
+#: ../gui/GameConqueror.ui.h:54
+msgid "Save address list to file (CTRL+S)"
+msgstr "მისამართების სიის ფაილში შენახვა (CTRL+ S)"
+
+#: ../gui/GameConqueror.ui.h:55
+msgid "Load address list from file (CTRL+O)"
+msgstr "ჩატვირთეთ მისამართების სია ფაილიდან (CTRL+O)"
+
+#: ../gui/GameConqueror.ui.h:56
+msgid "Remove all entries (CTRL+D)"
+msgstr "ყველა ჩანაწერის წაშლა (CTRL+D)"
+
+#: ../gui/GameConqueror.ui.h:57
+msgid "Manually add an entry (CTRL+M)"
+msgstr "ჩანაწერის ხელით დამატება (CTRL+M)"
+
+#: ../gui/GameConqueror.ui.h:58
+msgid ""
+"Copyright (C) 2009-2014 WANG Lu  <coolwanglu@gmail.com>\n"
+"Copyright (C) 2010 Bryan Cain\n"
+"Copyright (C) 2015-2016 Sebastian Parschauer  <s.parschauer@gmx.de>\n"
+"Copyright (C) 2016 Andrea Stacchiotti <andreastacchiotti(a)gmail.com>\n"
+"\n"
+"Special thanks: Igor Gnatenko, Mattias Muenster, Zhang Zhe"
+msgstr ""
+"საავტორო უფლებები (C) 2009-2014 WANG Lu <coolwanglu@gmail.com>\n"
+"საავტორო უფლებები (C) 2010 ბრიან კაენი\n"
+"საავტორო უფლებები (C) 2015-2016 სებასტიან პარშაუერი <s.parschauer@gmx.de>\n"
+"საავტორო უფლებები (C) 2016 ანდრეა სტაჩიოტი <andreastacchiotti (a)gmail."
+"com>\n"
+"\n"
+"განსაკუთრებული მადლობა: იგორ გნატენკო, მატიას მუენსტერი, ჟანგ ჟე"
+
+#: ../gui/GameConqueror.ui.h:64
+msgid "A graphical frontend of scanmem"
+msgstr "გრაფიკული წინაბოლო scanmem-სთვის"
+
+#: ../gui/GameConqueror.ui.h:65
+msgid "Homepage"
+msgstr "Homepage"
+
+#: ../gui/GameConqueror.ui.h:66
+msgid "Manually add an entry"
+msgstr "ჩანაწერის ხელით დამატება"
+
+#: ../gui/GameConqueror.ui.h:67
+msgid "_Add"
+msgstr "_დამატება"
+
+#: ../gui/GameConqueror.ui.h:68
+msgid "_Close"
+msgstr "დახურვა"
+
+#: ../gui/GameConqueror.ui.h:69
+msgid "Memory address of the value"
+msgstr "მნიშვნელობის მეხსიერების მისამართი"
+
+#: ../gui/GameConqueror.ui.h:70
+msgid "Addres_s:"
+msgstr "_მისამართი:"
+
+#: ../gui/GameConqueror.ui.h:71
+msgid "Give a brief description of the value"
+msgstr "მნიშვნელობის მოკლე აღწერა"
+
+#: ../gui/GameConqueror.ui.h:72
+msgid "_Description:"
+msgstr "_აღწერა:"
+
+#: ../gui/GameConqueror.ui.h:73
+msgid "_Type:"
+msgstr "ტიპი:"
+
+#: ../gui/GameConqueror.ui.h:74
+msgid "Specify data length (string/bytearray only)"
+msgstr ""
+"მიუთითეთ მონაცემების სიგრძე (მხოლოდ სტრიქონისთვის/ბაიტების მასივისთვის)"
+
+#: ../gui/GameConqueror.ui.h:75
+msgid "_Length:"
+msgstr "სიგრძე:"
+
+#: ../gui/GameConqueror.ui.h:76
+msgid "Type to search for a process"
+msgstr "პროცესის მოსაძებნად აკრიფეთ"
+
+#: ../gui/GameConqueror.ui.h:77
+msgid "_OK"
+msgstr "კარგი"
+
+#: ../gui/GameConqueror.ui.h:78
+msgid "_Cancel"
+msgstr "&გაუქმება"
+
+#: ../gui/GameConqueror.ui.h:79
+msgid "_User:"
+msgstr "_მომხმარებელი:"
+
+#: ../gui/GameConqueror.ui.h:80
+msgid "_Process:"
+msgstr "_პროცესი:"
+
+#: ../gui/GameConqueror.ui.h:81
+msgid "Filter"
+msgstr "ფილტრი"
+
+#: ../gui/GameConqueror.py:73
+msgid "Basic"
+msgstr "ძირითადი"
+
+#: ../gui/GameConqueror.py:73
+msgid "Normal"
+msgstr "ნორმალური"
+
+#: ../gui/GameConqueror.py:73
+msgid "ReadOnly"
+msgstr "მხოლოდწასაკითხად"
+
+#: ../gui/GameConqueror.py:73
+msgid "Full"
+msgstr "მთლიანი"
+
+#. init columns
+#. Address
+#: ../gui/GameConqueror.py:181 ../gui/GameConqueror.py:222
+msgid "Address"
+msgstr "მისამართი"
+
+#. Value
+#: ../gui/GameConqueror.py:185 ../gui/GameConqueror.py:239
+msgid "Value"
+msgstr "მნიშვნელობა"
+
+#: ../gui/GameConqueror.py:189
+msgid "Offset"
+msgstr "წანაცვლება"
+
+#: ../gui/GameConqueror.py:193
+msgid "Region Type"
+msgstr "რეგიონის ტიპი"
+
+#. Lock
+#: ../gui/GameConqueror.py:205
+msgid "Lock"
+msgstr "ჩაკეტვა"
+
+#. Description
+#: ../gui/GameConqueror.py:214
+msgid "Description"
+msgstr "აღწერა"
+
+#. Type
+#: ../gui/GameConqueror.py:227
+msgid "Type"
+msgstr "ტიპი"
+
+#. second col
+#: ../gui/GameConqueror.py:264
+msgid "User"
+msgstr "მომხმარებელი"
+
+#. third col
+#: ../gui/GameConqueror.py:269
+msgid "Process"
+msgstr "პროცესი"
+
+#: ../gui/GameConqueror.py:300
+msgid "Add to cheat list"
+msgstr "მოტყუების სიაში დამატება"
+
+#: ../gui/GameConqueror.py:301 ../gui/GameConqueror.py:308
+msgid "Browse this address"
+msgstr "ამ მისამართის დათვალიერება"
+
+#: ../gui/GameConqueror.py:302
+msgid "Scan for this address"
+msgstr "ამ მისამართის სკანირება"
+
+#: ../gui/GameConqueror.py:303
+msgid "Remove this match"
+msgstr "ამ დამთხვევის წაშლა"
+
+#: ../gui/GameConqueror.py:309
+msgid "Copy address"
+msgstr "მისამართის კოპირება"
+
+#: ../gui/GameConqueror.py:310
+msgid "Remove this entry"
+msgstr "ამ ჩანაწერის წაშლა"
+
+#: ../gui/GameConqueror.py:338 ../gui/GameConqueror.py:526
+#: ../gui/GameConqueror.py:993
+msgid "Please select a process"
+msgstr "გთხოვთ აირჩიოთ პროცესი"
+
+#: ../gui/GameConqueror.py:351
+msgid "Invalid address"
+msgstr "არასწორი მისამართი"
+
+#: ../gui/GameConqueror.py:361
+msgid "Please enter a valid address."
+msgstr "შეიყვანეთ სწორი მისამართი."
+
+#: ../gui/GameConqueror.py:365 ../gui/GameConqueror.py:880
+msgid "No Description"
+msgstr "აღწერის გარეშე"
+
+#: ../gui/GameConqueror.py:394
+msgid "Open.."
+msgstr "გახსნა.."
+
+#: ../gui/GameConqueror.py:414
+msgid "Save.."
+msgstr "_შენახვა..."
+
+#: ../gui/GameConqueror.py:519
+msgid "<unknown>"
+msgstr "<უცნობი>"
+
+#: ../gui/GameConqueror.py:567 ../gui/GameConqueror.py:862
+msgid "Cannot read memory"
+msgstr "მეხსიერებიდან წაკითხვის შეცდომა"
+
+#: ../gui/GameConqueror.py:818
+msgid "Unknown architecture, you may report to developers"
+msgstr "არქიტექტურა უცნობია. შეგიძლიათ, პროგრამისტებს დაუკავშირდეთ"
+
+#: ../gui/GameConqueror.py:830 ../gui/GameConqueror.py:921
+msgid ""
+"Cannot retrieve memory maps of that process, maybe it has exited (crashed), "
+"or you don't have enough privileges"
+msgstr ""
+"პროცესის მეხსიერების რუკების მიღების შეცდომა. შეიძლება, ის ან დასრულდა "
+"(ავარიულად), ან საკმარისი პრივილეგიები არ გაგაჩნიათ"
+
+#. not readable
+#: ../gui/GameConqueror.py:841
+#, python-format
+msgid "Address %x is not readable"
+msgstr "მისამართის %x ჩაწერადი არაა"
+
+#: ../gui/GameConqueror.py:844
+#, python-format
+msgid "Address %x is not valid"
+msgstr "მისამართი %x არასწორია"
+
+#: ../gui/GameConqueror.py:853
+msgid "Cannot find a readable region"
+msgstr "წაკითხვადი რეგიონის მოძებნა შეუძლებელია"
+
+#: ../gui/GameConqueror.py:1053
+#, python-format
+msgid "Found: %d"
+msgstr "მოიძებნა: %d"
+
+#: ../gui/GameConqueror.py:1168
+msgid ""
+"Version of scanmem mismatched, you may encounter problems. Please make sure "
+"you are using the same version of GameConqueror as scanmem."
+msgstr ""
+"Scanmem-ის ვერსია არ ემთხვევა. შეიძლება პრობლემები შეგექმნათ. დარწმუნდით, "
+"რომ GameConqueror-ის და scanmem-ის იგივე ვერსიებს იყენებთ."
+
+#: ../gui/GameConqueror.py:1174
+msgid "A GUI for scanmem, a game hacking tool"
+msgstr "ინტერფეისის წინაბოლო scanmem-სთვის.. ის თამაშის დასაჰაკი პროგრამაა"
+
+#: ../gui/GameConqueror.py:1175
+msgid "Report bugs to "
+msgstr "შეცდომების შესახებ მიწერეთ "
+
+#: ../gui/GameConqueror.py:1177
+msgid "prefill the search box"
+msgstr "ძებნის ზოლის წინასწარი შევსება"
+
+#: ../gui/GameConqueror.py:1179
+msgid "PID of the process"
+msgstr "პროცესის PID-ით"
+
+#: ../gui/misc.py:33
+msgid "No value provided"
+msgstr "მნიშვნელობა მითითებული არაა"
+
+#: ../gui/misc.py:51 ../gui/misc.py:57 ../gui/misc.py:104
+#, python-format
+msgid "Bad value: %s"
+msgstr "არასწორი მნიშვნელობა: %s"
+
+#: ../gui/misc.py:65
+#, python-format
+msgid "Command \"%s\" is not valid for the first scan"
+msgstr "ბრძანება \"%s\" პირველი სკანირებისას არასწორია"
+
+#: ../gui/misc.py:112
+#, python-format
+msgid "%s is not an integer"
+msgstr "%s მთელი რიცხვი არაა"
+
+#: ../gui/misc.py:118
+#, python-format
+msgid "%s is too bulky for %s"
+msgstr "%s ძალიან დიდია %s-სთვის"
+
+#: ../gui/misc.py:138
+#, python-format
+msgid "Cannot locate item: %s"
+msgstr "ელემენტის აღმოჩენა შეუძლებელია: %s"
+
+#: ../gui/org.scanmem.gameconqueror.desktop.in.h:1
+#: ../gui/org.scanmem.gameconqueror.metainfo.xml.in.h:1
+msgid "Game Conqueror"
+msgstr "Game Conqueror"
+
+#: ../gui/org.scanmem.gameconqueror.desktop.in.h:2
+msgid "A game hacking tool. A GUI front-end for scanmem."
+msgstr "თამაშის დასაჰაკი პროგრამა. ინტერფეისის წინაბოლო scanmem-სთვის."
+
+#: ../gui/org.freedesktop.gameconqueror.policy.in.in.h:1
+msgid "Run Game Conqueror"
+msgstr "Game Conqueror-ის გაშვება"
+
+#: ../gui/org.freedesktop.gameconqueror.policy.in.in.h:2
+msgid "Authentication is required to run Game Conqueror"
+msgstr "Game Conqueror-ის გასაშვებად ავთენტიკაცია გჭირდებათ"
+
+#: ../gui/org.scanmem.gameconqueror.metainfo.xml.in.h:2
+msgid "Game hacking tool. GUI front-end for scanmem."
+msgstr "თამაშის დასაჰაკი პროგრამა. ინტერფეისის წინაბოლო scanmem-სთვის."
+
+#: ../gui/org.scanmem.gameconqueror.metainfo.xml.in.h:3
+msgid ""
+"scanmem is a simple interactive debugging utility, used to locate the "
+"address of a variable in an executing process. This can be used for the "
+"analysis or modification of a hostile process on a compromised machine, "
+"reverse engineering, or as a \"pokefinder\" to cheat at video games. "
+"GameConqueror aims to provide a CheatEngine-alike interface for scanmem, "
+"it's user-friendly and easy to use."
+msgstr ""
+"scanmem-ი მარტივი, ინტერაქტიური გამართვის პროგრამაა, რომელის გაშვებულ "
+"პროცესში მნიშვნელობის მისამართის მოსაძებნად შეგიძლიათ, გამოიყენოთ. ასევე "
+"შეგიძლიათ გატეხილ მანქანაზე მტრული პროცესის ანალიზისთვის თამაშებში "
+"\"ჩიტებისთვის\" და რევერსიული ინჟინერიისთვისაც გამოიყენოთ."
+
+#: ../gui/org.scanmem.gameconqueror.metainfo.xml.in.h:4
+msgid "Features:"
+msgstr "თვისებები:"
+
+#: ../gui/org.scanmem.gameconqueror.metainfo.xml.in.h:5
+msgid "Locking on multiple variables"
+msgstr "ბევრ ცვლადის დაკვირვება"
+
+#: ../gui/org.scanmem.gameconqueror.metainfo.xml.in.h:6
+msgid "Memory Viewer/Editor"
+msgstr "მეხსიერების დათვალიერება/ჩასწორება"
+
+#: ../gui/org.scanmem.gameconqueror.metainfo.xml.in.h:7
+msgid "... many to be done"
+msgstr "... გასაკეთებელი კიდევ ბევრია"

--- a/ptrace.c
+++ b/ptrace.c
@@ -701,6 +701,9 @@ bool sm_setaddr(pid_t target, void *addr, const value_t *to)
 
     unsigned int val_length = flags_to_memlength(ANYNUMBER, to->flags);
     if (val_length > 0) {
+        if (val_length > sizeof(memarray))
+            val_length = sizeof(memarray);
+
         /* Basically, overwrite as much of the data as makes sense, and no more. */
         memcpy(memarray, to->bytes, val_length);
     }

--- a/targetmem.c
+++ b/targetmem.c
@@ -85,15 +85,20 @@ void data_to_printable_string (char *buf, int buf_length,
                                size_t index, int string_length)
 {
     long swath_length = swath->number_of_bytes - index;
-    /* TODO: what if length is too large ? */
     long max_length = (swath_length >= string_length) ? string_length : swath_length;
     int i;
+
+    if (buf_length <= 0)
+        return;
+
+    if (max_length > buf_length - 1)
+        max_length = buf_length - 1;
 
     for (i = 0; i < max_length; ++i) {
         uint8_t byte = swath->data[index+i].old_value;
         buf[i] = isprint(byte) ? byte : '.';
     }
-    buf[i] = 0; /* null-terminate */
+    buf[i] = 0;
 }
 
 void data_to_bytearray_text (char *buf, int buf_length,
@@ -104,18 +109,31 @@ void data_to_bytearray_text (char *buf, int buf_length,
     int bytes_used = 0;
     long swath_length = swath->number_of_bytes - index;
 
-    /* TODO: what if length is too large ? */
+    if (buf_length <= 0)
+        return;
+
     long max_length = (swath_length >= bytearray_length) ?
                        bytearray_length : swath_length;
 
     for (i = 0; i < max_length; ++i) {
         uint8_t byte = swath->data[index+i].old_value;
+        int room = buf_length - bytes_used;
 
-        /* TODO: check error here */
-        snprintf(buf+bytes_used, buf_length-bytes_used,
-                 (i<max_length-1) ? "%02x " : "%02x", byte);
-        bytes_used += 3;
+        if (room <= 0)
+            break;
+
+        int wrote = snprintf(buf + bytes_used, room,
+                             (i < max_length - 1) ? "%02x " : "%02x", byte);
+        if (wrote < 0)
+            break;
+        if (wrote >= room) {
+            bytes_used = buf_length - 1;
+            break;
+        }
+        bytes_used += wrote;
     }
+
+    buf[bytes_used] = 0;
 }
 
 match_location

--- a/targetmem.h
+++ b/targetmem.h
@@ -258,7 +258,7 @@ data_to_val_aux (const matches_and_old_values_swath *swath,
                  size_t index, size_t swath_length)
 {
     unsigned int i;
-    value_t val;
+    volatile value_t val;
     size_t max_bytes = swath_length - index;
 
     /* Init all possible flags in a single go.


### PR DESCRIPTION
## Summary

Bundles maintainer backlog fixes into one reviewable 0.18.0 prep branch (`miracle-update`).

### Security / stability
- Bounds checks in printable-string formatting (#449)
- Cap `/proc` maps pathname buffer; fix sscanf field types (#452, supersedes #455 maps half)
- Clamp ptrace poke length
- Process list via `/proc` instead of `ps` popen (#434)

~~Drop `system()` from shell handler; use `execvp`~~ reverted in 38795b8, see review discussion. It was not a security fix and it broke globs, pipes and variable expansion in `!` escapes.

### Compiler / portability
- `-Wclobbered` fixes in `handler__set` (#381)
- `sig_atomic_t` interrupt flag
- `volatile` scratch in `data_to_val_aux`
- Gtk 3 `require_version` before PyGI import (#398)
- Launch GameConqueror with `python3` (#438), and drop the py2 shims behind it
- Android cross compiler selection from `HOST` (#441), any API level. Logic tested against fake toolchain layouts, **not** verified on real hardware or a real NDK.

### GUI / i18n
- Memory viewer display type selector (#448, credit sqrt0x)
- Georgian translation (#426, credit NorwayFun)

### Release
- `configure.ac` bumped to 0.18.0
- `NEWS` entry for #397

## Build
Kali build with `-D_FORTIFY_SOURCE=3 -fstack-protector-strong` passes (`--disable-gui`).

## Not included (needs separate review)
#424 XOR, #403 monitoring, #389 undo, #348 stack offset, #346 read value, #312/#145 sm_reset, #450 GTK4.

Closes #449, #452, #438, #398, #441, #434 (partial via /proc list). Credits #448 #426 #381.
