### PR TITLE
targetmem: stop doing pointer math on the pre-realloc pointer

### DIFF
--- a/targetmem.h
+++ b/targetmem.h
@@ -138,7 +138,13 @@ allocate_enough_to_reach (matches_and_old_values_array *array,
         return array;
 
     } else {
-        matches_and_old_values_array *original_location = array;
+        /* Note where the swath sits inside the array before the realloc.
+           Doing that arithmetic against the old pointer afterwards is
+           undefined once realloc has taken it, and gcc 12+ warns on it. */
+        size_t swath_offset = 0;
+        if (swath_pointer_to_correct)
+            swath_offset = (size_t)((char *)(*swath_pointer_to_correct)
+                                    - (char *)array);
 
         /* allocate twice as much each time,
            so we don't have to do it too often */
@@ -160,13 +166,10 @@ allocate_enough_to_reach (matches_and_old_values_array *array,
 
         array->bytes_allocated = bytes_to_allocate;
 
-        /* Put the swath pointer back where it should be, if needed.
-           We cast everything to void pointers in this line to make
-           sure the math works out. */
+        /* Put the swath pointer back where it should be, if needed. */
         if (swath_pointer_to_correct) {
             (*swath_pointer_to_correct) = (matches_and_old_values_swath *)
-                (((void *)(*swath_pointer_to_correct)) +
-                 ((void *)array - (void *)original_location));
+                ((char *)array + swath_offset);
         }
 
         return array;


### PR DESCRIPTION
this is the one i said i would split out rather than smuggle into #457. independent of that pr, touches lines 138 to 175 where #457 only touches 258, so the two do not conflict either way round.

`allocate_enough_to_reach()` grows the match array, then fixes up the caller's swath pointer by adding `(new_array - old_array)`. problem is `old_array` was handed to realloc on the line above, so reading that pointer value afterwards is undefined, the allocator owns it. gcc 12+ flags it, on gcc 15.3 it is the only warning in the whole build:

```
targetmem.h:169:33: warning: pointer 'original_location' may be used after 'realloc' [-Wuse-after-free]
```

fix records the swath's byte offset into the array *before* the realloc and rebuilds the pointer from the new base after. identical result, no arithmetic on the dead pointer, and `original_location` goes away entirely.

verification, since getting this wrong silently corrupts every stored match rather than crashing loudly:

build goes from 2 warnings to 0, no other warnings. `make check` passes 1/1.

then the path that actually matters. 200k identical ints in a target process, so the array has to grow repeatedly and fix the swath pointer up each time:

```
> 4242
info: we currently have 200000 matches.
> 777        (target rewrote all 200k in between)
info: we currently have 200000 matches.
```

exact count both ways. the narrowing scan has to walk every stored address, so if the fixup were off by anything it would come back short, garbage, or segfault. it does not.

not verified under ASan specifically, the ci job builds with it so that will cover it here.