### PR TITLE
ptrace: say why the attach failed instead of just EPERM

### DIFF
--- a/ptrace.c
+++ b/ptrace.c
@@ -94,6 +94,30 @@ static struct {
 } peekbuf;
 
 
+/* Who is already ptracing `target`? Returns 0 if nobody, or if we cannot tell
+   (no /proc, so BSD just falls back to the plain errno message). */
+static pid_t tracer_pid_of(pid_t target)
+{
+    char path[64];
+    char line[256];
+    FILE *f;
+    pid_t tracer = 0;
+
+    snprintf(path, sizeof(path), "/proc/%d/status", target);
+    if ((f = fopen(path, "r")) == NULL)
+        return 0;
+
+    while (fgets(line, sizeof(line), f) != NULL) {
+        if (strncmp(line, "TracerPid:", 10) == 0) {
+            tracer = (pid_t)strtol(line + 10, NULL, 10);
+            break;
+        }
+    }
+
+    fclose(f);
+    return tracer;
+}
+
 bool sm_attach(pid_t target)
 {
     if (!sm_globals.options.no_ptrace)
@@ -102,7 +126,21 @@ bool sm_attach(pid_t target)
 
         /* attach to the target application, which should cause a SIGSTOP */
         if (ptrace(PTRACE_ATTACH, target, NULL, NULL) == -1L) {
-            show_error("failed to attach to %d, %s\n", target, strerror(errno));
+            int attach_errno = errno;
+            pid_t tracer = tracer_pid_of(target);
+
+            show_error("failed to attach to %d, %s\n", target,
+                       strerror(attach_errno));
+
+            /* "Operation not permitted" covers two very different problems and
+               the bare errno sends people down the wrong one, see #392, #393 */
+            if (tracer > 0) {
+                show_info("%d is already being traced by process %d, "
+                          "detach that first.\n", target, tracer);
+            } else if (attach_errno == EPERM) {
+                show_info("run scanmem as root, or check whether "
+                          "/proc/sys/kernel/yama/ptrace_scope allows it.\n");
+            }
             return false;
         }
 


### PR DESCRIPTION
closes #392, closes #393

both of those are the same underlying complaint. `Operation not permitted` on attach has two common causes that look identical from the error message, so people chase the wrong one:

- something is already tracing the process, usually a gdb or strace someone forgot about
- yama `ptrace_scope` will not let us attach even as the same user

#392 asked for exactly this ("check the process status before attempting to attach, and return a clear message"), and #393 is someone hitting the second one and getting no hint.

on failure we now read `TracerPid` out of `/proc/<pid>/status`. if something holds it, name the pid. otherwise, if it was EPERM, point at ptrace_scope. where there is no /proc the helper returns 0 and you get the old message unchanged, so bsd is not affected.

reproduced both, this is real output not a mockup.

already traced, with strace holding it:

```
error: failed to attach to 1664605, Operation not permitted
info: 1664605 is already being traced by process 1666206, detach that first.
```

1666206 was the actual strace pid. and with `ptrace_scope=1`, no tracer:

```
error: failed to attach to 1664605, Operation not permitted
info: run scanmem as root, or check whether /proc/sys/kernel/yama/ptrace_scope allows it.
```

then detached the tracer and confirmed the normal path is untouched, attach, scan, write all still fine (`21 matches`, `setting *0x... to 0x3e7`).

builds clean, no new warnings. does not touch the same lines as #457 (that hits ptrace.c around 701, this is `sm_attach` at 97) so they are independent in either order.