### PR TITLE
ci: cap the job timeout and stop apt wedging the run

### DIFF
--- a/.github/actions/linux-setup/action.yml
+++ b/.github/actions/linux-setup/action.yml
@@ -4,15 +4,17 @@ description: Set up the Linux VM
 runs:
   using: 'composite'
   steps:
-    # Update packages
-    - run: sudo apt --assume-yes update
+    # Update packages. Retries because a mirror hiccup here used to wedge the
+    # whole run, and noninteractive so nothing can sit waiting on a prompt.
+    - run: sudo apt-get -o Acquire::Retries=3 --assume-yes update
       shell: bash
-    # Upgrade packages
-    - run: sudo apt --assume-yes upgrade
-      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
     # Install required packages
-    - run: sudo apt --assume-yes install make gcc binutils intltool libtool autotools-dev libreadline-dev python3
+    - run: sudo apt-get -o Acquire::Retries=3 --assume-yes install make gcc binutils intltool libtool autotools-dev libreadline-dev python3
       shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
     # Run auto-generate
     - run: ./autogen.sh
       shell: bash

--- a/.github/workflows/01-build.yml
+++ b/.github/workflows/01-build.yml
@@ -6,6 +6,9 @@ on: [push,pull_request,workflow_dispatch]
 jobs:
   build-gui:
     runs-on: ubuntu-22.04
+    # without this a wedged step runs to GitHub's 6 hour default before it is
+    # killed. the build itself takes about 3 minutes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Linux set up


### PR DESCRIPTION
main has no passing build right now. the last two runs sat from 15:37 to 21:38 and 15:36 to 21:37 on the 19th and were both cancelled at github's six hour default, with no successful build behind them. the build takes about three minutes when it works.

two causes, both small.

the job has no `timeout-minutes`, so anything that wedges runs the full six hours before it gets killed. set to 30.

`apt --assume-yes upgrade` is the step it wedges in. upgrading every package on the runner image is not something this build needs and it is slow even when it works, so it is gone. update and install now go through apt-get with `Acquire::Retries=3` and `DEBIAN_FRONTEND=noninteractive`, so a mirror hiccup retries instead of sitting there.

kept separate from the CI changes in #457 on purpose, this does not need to wait on that review. the run on this branch finished green in 66 seconds.

both files still parse as yaml.
