### PR TITLE
Work through the open PR backlog

### DIFF
--- a/.github/workflows/01-build.yml
+++ b/.github/workflows/01-build.yml
@@ -8,13 +8,6 @@ jobs:
     name: ${{ matrix.cc }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    # clang does not fail the run yet. It builds clean but the scans come back
-    # wrong at -O1 and above, and that is not new: upstream 0375cc0 fails the
-    # same way, gcc is fine at every level, and clang -O0 is fine. It went
-    # unnoticed because the old suite asserted nothing about results and CI
-    # only ever built with gcc. Kept in the matrix so the failure stays
-    # visible instead of being dropped.
-    continue-on-error: ${{ matrix.cc == 'clang' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -40,11 +40,12 @@ gui/*.pyc
 gui/*.pyo
 gui/__pycache__
 gui/gameconqueror
-gui/org.freedesktop.gameconqueror.policy
-gui/org.freedesktop.gameconqueror.policy.in
+gui/org.scanmem.gameconqueror.policy
+gui/org.scanmem.gameconqueror.policy.in
 
 # Translations
 po/.intltool-merge-cache
+po/.intltool-merge-cache.lock
 po/GameConqueror.pot
 po/Makefile.in.in
 po/POTFILES

--- a/bench/BASELINE.md
+++ b/bench/BASELINE.md
@@ -75,23 +75,37 @@ chunking. It was two orphaned scanmem processes from earlier timed out runs
 sitting at 95% CPU. On an idle machine threads=1 is level with serial. Check
 what else is running before believing a regression this size.
 
-# Known: clang builds scan wrong
+# The clang "miscompile" that was not one
 
-Worth writing down because it cost a while to pin down. scanmem built with
-clang at -O1 or higher finds almost nothing. The scan runs, reads the right
-memory, parses the right value and picks the right routine, and still returns
-3 matches where gcc returns 102.
+Worth keeping because I got this wrong for a while and the wrong version is
+more believable than the right one.
 
-Not introduced by any of the work above. Upstream 0375cc0 fails identically
-once you point an asserting test suite at it, which nothing did before, since
-the old suite only checked that scanmem exited zero and CI only built gcc.
+scanmem built with clang at -O1 or higher used to find almost nothing, 4 of 23
+checks against 23 of 23 at -O0. gcc was fine at every level. It reproduced on
+upstream 0375cc0 too, so it clearly predated any of the work here. Everything
+pointed at a real miscompile in the scan path.
 
-Ruled out so far: strict aliasing (-fno-strict-aliasing does not help),
-vectorisation, signed overflow (-fwrapv), and the extern inline definitions
-(removing them entirely does not help). -fno-inline takes it from 4/23 to
-16/23 checks passing, so inlining is exposing it rather than causing it.
+It was the test fixture. test/memfake allocates a buffer, plants values in it
+and then sits in pause(). Nothing in that process ever reads the buffer back,
+because the whole point is that the scanner reads it over ptrace. clang at -O1
+works that out, decides the stores are dead and removes them. The target
+simply never held the values, so of course the scan found nothing. scanmem
+itself was correct the whole time.
 
-Reproduce:
+What made it look like a compiler bug in scanmem: the build flags from
+configure reach both scanmem and memfake, so "build with clang -O2" changed
+the target as well as the scanner, and every symptom tracked the optimisation
+level. The tell that should have been followed sooner is that no single
+translation unit at -O0 fixed it and no single one at -O2 broke it, which is
+not how a miscompile in one function behaves.
 
-    ./configure CC=clang CFLAGS='-O2 -Wall' && make
-    sudo make check
+Fixed by forcing the writes to stay observable in memfake:
+
+    static void keep(void *p) { __asm__ __volatile__("" :: "r"(p) : "memory"); }
+
+called after the initial plant and after each mutation. clang is a blocking
+CI job again.
+
+The general version: a test fixture built with the same optimiser as the code
+under test can be optimised out from under the test. Same class of thing as
+building memfake unsanitized for the ASan job.

--- a/build_for_android.sh
+++ b/build_for_android.sh
@@ -44,6 +44,10 @@ if [ "x$1" = "x--help" ] || [ "x$1" = "xhelp" ] || [ "x$1" = "x-h" ]; then
       capabilities.
   HOST                     - Compiler architecture that will be used for
       cross-compiling, default is arm-linux-androideabi
+  API                      - Android api level of the clang wrapper to use,
+      default 21. Current NDKs name them like aarch64-linux-android21-clang
+  CC                       - Set this to pick the compiler yourself, otherwise
+      it is found in \$NDK_STANDALONE_TOOLCHAIN/bin
   SCANMEM_HOME             - Path which has scanmem sources, and will be used
       to build scanmem.  Default current directory
   LIBREADLINE_DIR          - Path which has libreadline sources to build
@@ -74,6 +78,61 @@ if [ "x${HOST}" = "x" ]; then
   echo "Env variable \$HOST, host architecture, is not specified.
 Defaulting to ${HOST}"
 fi
+
+# NDK r19 dropped standalone toolchains. What you get now is one llvm
+# directory with a clang wrapper per api level, named like
+# aarch64-linux-android21-clang, so the plain ${HOST}-gcc that configure
+# goes looking for does not exist. configure does not treat that as an
+# error, it falls back to the build machine's cc and hands you an x86_64
+# binary. Pick the compiler here and stop if there is not one.
+API="${API:-21}"
+
+# 32 bit arm is the odd one out, binutils used arm-linux-androideabi but
+# the clang wrapper is armv7a-linux-androideabi
+CLANG_HOST="${HOST}"
+if [ "x${HOST}" = "xarm-linux-androideabi" ]; then
+  CLANG_HOST=armv7a-linux-androideabi
+fi
+
+if [ "x${CC}" = "x" ]; then
+  for candidate in \
+      "${NDK_STANDALONE_TOOLCHAIN}/bin/${CLANG_HOST}${API}-clang" \
+      "${NDK_STANDALONE_TOOLCHAIN}/bin/${HOST}-clang" \
+      "${NDK_STANDALONE_TOOLCHAIN}/bin/${HOST}-gcc"; do
+    if [ -x "${candidate}" ]; then
+      CC="${candidate}"
+      break
+    fi
+  done
+fi
+
+if [ "x${CC}" = "x" ]; then
+  echo "Error: no compiler for ${HOST} in ${NDK_STANDALONE_TOOLCHAIN}/bin" 1>&2
+  echo "Looked for ${CLANG_HOST}${API}-clang, ${HOST}-clang and ${HOST}-gcc." 1>&2
+  echo "Check \$HOST, and \$API if your toolchain only has other api levels." 1>&2
+  echo "Without one of these configure quietly builds for this machine instead." 1>&2
+  exit 1
+fi
+export CC
+echo "Using ${CC}"
+
+[ "x${CXX}" = "x" ] && [ -x "${CC}++" ] && export CXX="${CC}++"
+
+# llvm-ar and friends in the same directory, the prefixed binutils names
+# are gone in current NDKs
+for tool in ar ranlib strip nm; do
+  upper="$(echo ${tool} | tr 'a-z' 'A-Z')"
+  eval "current=\${${upper}}"
+  [ "x${current}" != "x" ] && continue
+  for candidate in \
+      "${NDK_STANDALONE_TOOLCHAIN}/bin/llvm-${tool}" \
+      "${NDK_STANDALONE_TOOLCHAIN}/bin/${HOST}-${tool}"; do
+    if [ -x "${candidate}" ]; then
+      eval "export ${upper}=\"${candidate}\""
+      break
+    fi
+  done
+done
 
 # Build and return directory
 if [ "x${SCANMEM_HOME}" = "x" ]; then
@@ -151,4 +210,18 @@ fi
 LIBS="-lncurses -lm" ./configure --host="${HOST}" --prefix="${SYSROOT}/usr" \
     --enable-static --disable-shared
 [ "$?" != "0" ] && exit 1
-make -j ${procnum} && make install
+make -j ${procnum} && make install || exit 1
+
+# say what came out, so a build that silently targeted this machine is
+# obvious rather than something you find out on the device
+if command -v file >/dev/null 2>&1 && [ -f scanmem ]; then
+  echo
+  echo "Built: $(file -b scanmem)"
+  case "$(file -b scanmem)" in
+    *Android*|*ARM*|*aarch64*) ;;
+    *)
+      echo "Warning: that does not look like an Android binary." 1>&2
+      echo "Check that \$HOST matches your device and that ${CC} is the right compiler." 1>&2
+      ;;
+  esac
+fi

--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,7 @@ AS_IF([test "x$enable_gui" = "xyes"], [
     gui/icons/Makefile
     gui/consts.py
     gui/gameconqueror
-    gui/org.freedesktop.gameconqueror.policy.in
+    gui/org.scanmem.gameconqueror.policy.in
   ])
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -210,9 +210,11 @@ AS_IF([test "x$enable_gui" = "xyes"], [
     gui/Makefile
     gui/icons/Makefile
     gui/consts.py
-    gui/gameconqueror
     gui/org.scanmem.gameconqueror.policy.in
   ])
+  dnl config.status writes this without the executable bit, so running it
+  dnl straight out of the build tree gives you "Permission denied"
+  AC_CONFIG_FILES([gui/gameconqueror], [chmod +x gui/gameconqueror])
 ])
 
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -205,7 +205,7 @@ AS_IF([test "x$enable_gui" = "xyes"], [
   AS_AC_EXPAND(LOCALEDIR, $localedir)
   AS_AC_EXPAND(LIBDIR, $libdir)
 
-  AM_PATH_PYTHON([2.7])
+  AM_PATH_PYTHON([3])
   AC_CONFIG_FILES([
     gui/Makefile
     gui/icons/Makefile

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
     Game Conqueror: a graphical game cheating tool, using scanmem as its backend
     

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -211,7 +211,9 @@ class GameConqueror():
         # init CheatList TreeView
         self.cheatlist_tv = self.builder.get_object('CheatList_TreeView')
         # cheatlist contents:                    locked, description, addr,                type, value, valid, lock flag
-        self.cheatlist_liststore = Gtk.ListStore(bool,   str,         GObject.TYPE_UINT64, str,  str,   bool,  str)
+        # last column is the field length in bytes, only meaningful for
+        # string and bytearray. 0 means work it out from the value.
+        self.cheatlist_liststore = Gtk.ListStore(bool,   str,         GObject.TYPE_UINT64, str,  str,   bool,  str, int)
         self.cheatlist_tv.set_model(self.cheatlist_liststore)
         self.cheatlist_editing = False
         # Lock
@@ -431,7 +433,9 @@ class GameConqueror():
                     for row in obj['cheat_list']:
                         # files saved before lock flags existed have 6 fields
                         lockflag = row[6] if len(row) > 6 else '='
-                        self.add_to_cheat_list(row[2],row[4],row[3],row[1],True,lockflag)
+                        # older files have no length, fall back to the value
+                        length = row[7] if len(row) > 7 else 0
+                        self.add_to_cheat_list(row[2],row[4],row[3],row[1],True,lockflag,length)
             except:
                 pass
         dialog.destroy()
@@ -778,7 +782,11 @@ class GameConqueror():
             if new_text == typestr:
                 continue
             if new_text in {'bytearray', 'string'}:
-                self.cheatlist_liststore[row][4] = self.bytes2value(new_text, self.read_memory(addr, self.get_type_size(typestr, value)))
+                length = self.cheatlist_liststore[row][7] or self.get_type_size(typestr, value)
+                self.cheatlist_liststore[row][4] = self.bytes2value(new_text, self.read_memory(addr, length))
+            else:
+                length = self.get_type_size(new_text, value)
+            self.cheatlist_liststore[row][7] = int(length or 0)
             self.cheatlist_liststore[row][3] = new_text
             self.cheatlist_liststore[row][0] = False # unlock
         return True
@@ -908,7 +916,7 @@ class GameConqueror():
         Gdk.threads_leave()
         return True
 
-    def add_to_cheat_list(self, addr, value, typestr, description=_('No Description'), at_end=False, lockflag='='):
+    def add_to_cheat_list(self, addr, value, typestr, description=_('No Description'), at_end=False, lockflag='=', length=0):
         # determine longest possible type
         types = typestr.split()
         vt = typestr
@@ -918,10 +926,13 @@ class GameConqueror():
                 break
         if lockflag not in LOCK_FLAGS:
             lockflag = '='
+        if not length:
+            length = int(self.get_type_size(vt, str(value)) or 0)
+        row = [False, description, addr, vt, str(value), True, lockflag, length]
         if at_end:
-            self.cheatlist_liststore.append([False, description, addr, vt, str(value), True, lockflag])
+            self.cheatlist_liststore.append(row)
         else:
-            self.cheatlist_liststore.prepend([False, description, addr, vt, str(value), True, lockflag])
+            self.cheatlist_liststore.prepend(row)
 
     def get_process_list(self):
         plist = []
@@ -1147,7 +1158,7 @@ class GameConqueror():
             for i in self.cheatlist_liststore:
                 if not (i[0] and i[5]): # locked and valid
                     continue
-                addr, typestr, value, lockflag = i[2], i[3], i[4], i[6]
+                addr, typestr, value, lockflag, length = i[2], i[3], i[4], i[6], i[7]
                 # '=' pins the value. bytearray/string have no ordering so
                 # they only ever get the plain lock, whatever the flag says.
                 if lockflag == '=' or typestr not in TYPESIZES:
@@ -1155,7 +1166,7 @@ class GameConqueror():
                     continue
                 # directional lock: let the game move the value the way we
                 # allow and keep that, push back when it goes the other way
-                newvalue = self.read_value(addr, typestr, value)
+                newvalue = self.read_value(addr, typestr, value, length)
                 if newvalue is None:
                     continue
                 try:
@@ -1172,13 +1183,13 @@ class GameConqueror():
             # Update visible (and unlocked) cheat list rows
             rows = self.get_visible_rows(self.cheatlist_tv)
             for i in rows:
-                locked, desc, addr, typestr, value, valid, lockflag = self.cheatlist_liststore[i]
+                locked, desc, addr, typestr, value, valid, lockflag, length = self.cheatlist_liststore[i]
                 if valid and not locked:
-                    newvalue = self.read_value(addr, typestr, value)
+                    newvalue = self.read_value(addr, typestr, value, length)
                     if newvalue is None:
-                        self.cheatlist_liststore[i] = (False, desc, addr, typestr, '??', False, lockflag)
+                        self.cheatlist_liststore[i] = (False, desc, addr, typestr, '??', False, lockflag, length)
                     elif newvalue != value and not self.cheatlist_editing:
-                        self.cheatlist_liststore[i] = (locked, desc, addr, typestr, str(newvalue), valid, lockflag)
+                        self.cheatlist_liststore[i] = (locked, desc, addr, typestr, str(newvalue), valid, lockflag, length)
             # Update visible scanresult rows
             rows = self.get_visible_rows(self.scanresult_tv)
             for i in rows:
@@ -1196,8 +1207,13 @@ class GameConqueror():
             self.command_lock.release()
         return not self.exit_flag
 
-    def read_value(self, addr, typestr, prev_value):
-        return self.bytes2value(typestr, self.read_memory(addr, self.get_type_size(typestr, prev_value)))
+    def read_value(self, addr, typestr, prev_value, length=0):
+        # a string or bytearray field is as long as it was when it was added.
+        # working it back out of the last value shrinks the field as soon as
+        # something shorter gets typed into it, and that is permanent.
+        if not length:
+            length = self.get_type_size(typestr, prev_value)
+        return self.bytes2value(typestr, self.read_memory(addr, length))
     
     # addr could be int or str
     def read_memory(self, addr, length):

--- a/gui/GameConqueror.py
+++ b/gui/GameConqueror.py
@@ -926,17 +926,27 @@ class GameConqueror():
     def get_process_list(self):
         plist = []
         for proc in os.popen('ps -wweo pid=,user:16=,command= --sort=-pid').readlines():
-            try:
-                (pid, user, pname) = [tok.strip() for tok in proc.split(None, 2)]
-            # process name may be empty, but not the name of the executable
-            except (ValueError):
-                (pid, user) = [tok.strip() for tok in proc.split(None, 1)]
+            parts = proc.split(None, 2)
+            # ps hands back a blank line on some systems. the old code caught
+            # the ValueError from the 3 way split and then split the same
+            # empty string again, raising the identical error out of its own
+            # except clause and taking the process list with it (#434)
+            if len(parts) < 2:
+                continue
+            pid, user = parts[0].strip(), parts[1].strip()
+            if len(parts) > 2:
+                pname = parts[2].strip()
+            else:
+                # process name may be empty, but not the name of the executable
                 exelink = os.path.join("/proc", pid, "exe")
                 if os.path.exists(exelink):
                     pname = os.path.realpath(exelink)
                 else:
                     pname = ''
-            plist.append((int(pid), user, pname))
+            try:
+                plist.append((int(pid), user, pname))
+            except ValueError:
+                continue  # not a pid, so not a row we can use
         return plist
 
     def select_process(self, pid, process_name):
@@ -1246,8 +1256,10 @@ if __name__ == '__main__':
         sys.exit(1)
 
     # Init application
-    GObject.threads_init()
-    Gdk.threads_init()
+    # GObject.threads_init and Gdk.threads_init used to live here. Both have
+    # been no-ops since PyGObject 3.11 and both emit a deprecation warning on
+    # every launch (#434). The threads_enter/leave pairs around the worker are
+    # a separate question and are left alone.
     gc_instance = GameConqueror()
 
     # Attach to given pid (if any)

--- a/gui/Makefile.am
+++ b/gui/Makefile.am
@@ -9,7 +9,7 @@ dist_gameconqueror_DATA = GameConqueror.ui GameConqueror_128x128.png \
 dist_desktop_in_files = org.scanmem.gameconqueror.desktop.in
 dist_desktop_DATA = $(dist_desktop_in_files:.desktop.in=.desktop)
 @INTLTOOL_DESKTOP_RULE@
-dist_polkit_in_files = org.freedesktop.gameconqueror.policy.in
+dist_polkit_in_files = org.scanmem.gameconqueror.policy.in
 dist_polkit_DATA = $(dist_polkit_in_files:.policy.in=.policy)
 @INTLTOOL_POLICY_RULE@
 dist_appdata_in_files = org.scanmem.gameconqueror.metainfo.xml.in

--- a/gui/gameconqueror.in
+++ b/gui/gameconqueror.in
@@ -2,9 +2,29 @@
 
 DATADIR=@PKGDATADIR@
 
-PKEXEC=$(command -v "pkexec")
-if [ -n "$PKEXEC" ]; then
-    $PKEXEC $DATADIR/GameConqueror.py "$@"
-else
-    echo "install policykit!"
+# pkexec only carries DISPLAY and XAUTHORITY across, and only because the
+# policy sets allow_gui. XAUTHORITY is often not set at all, in which case
+# X clients fall back to $HOME/.Xauthority, and root's HOME is not yours,
+# so the cookie is not found and the display cannot be opened. Point at it
+# while we still know where home is.
+if [ -z "$XAUTHORITY" ] && [ -f "$HOME/.Xauthority" ]; then
+    export XAUTHORITY="$HOME/.Xauthority"
 fi
+
+PKEXEC=$(command -v "pkexec")
+if [ -z "$PKEXEC" ]; then
+    echo "install policykit!"
+    exit 1
+fi
+
+$PKEXEC "$DATADIR/GameConqueror.py" "$@"
+status=$?
+
+# 126 and 127 are pkexec's own, the authorisation was refused or it could
+# not run the program at all. Anything else came from GameConqueror.
+if [ $status = 126 ] || [ $status = 127 ]; then
+    echo "gameconqueror: pkexec would not run $DATADIR/GameConqueror.py" >&2
+    echo "check that the polkit policy is installed and that the file is executable" >&2
+fi
+
+exit $status

--- a/gui/hexview.py
+++ b/gui/hexview.py
@@ -25,6 +25,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 from gi.repository import Pango
 from gi.repository import GObject
@@ -109,7 +111,7 @@ class AsciiText(BaseText):
     __gtype_name__ = 'AsciiText'
     _printable = \
         "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!\"#$%" \
-        "&'()*+,-./:;<=>?@[\]^_`{|}~ "
+        r"&'()*+,-./:;<=>?@[\]^_`{|}~ "
 
     def __init__(self, parent):
         super(AsciiText, self).__init__(parent)

--- a/gui/misc.py
+++ b/gui/misc.py
@@ -19,8 +19,12 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import ast
+import operator
 import sys
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 
 PY3K = sys.version_info >= (3, 0)
@@ -91,10 +95,47 @@ def check_scan_command (data_type, cmd, is_first_scan):
         # finally
         return cmd
 
+# The search box takes arithmetic, so "1024*1024" works as a value. That used
+# to go through eval(), which runs anything at all, in a process that started
+# itself under pkexec. Nobody but the person typing feeds this, so it was not
+# a way in, it was just a large amount of language reachable from a text box
+# that wants a number. Walk the expression instead and allow only arithmetic.
+_BINOPS = {
+    ast.Add: operator.add,       ast.Sub: operator.sub,
+    ast.Mult: operator.mul,      ast.Div: operator.truediv,
+    ast.FloorDiv: operator.floordiv, ast.Mod: operator.mod,
+    ast.Pow: operator.pow,
+    ast.LShift: operator.lshift, ast.RShift: operator.rshift,
+    ast.BitAnd: operator.and_,   ast.BitOr: operator.or_,
+    ast.BitXor: operator.xor,
+}
+_UNARYOPS = {ast.UAdd: operator.pos, ast.USub: operator.neg,
+             ast.Invert: operator.invert}
+
+def _eval_node(node):
+    # ast.Num is what python 2 and older 3 produce, Constant is 3.8+
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(node.value, (int, float)):
+            raise ValueError('not a number')
+        return node.value
+    if hasattr(ast, 'Num') and isinstance(node, ast.Num):
+        return node.n
+    if isinstance(node, ast.UnaryOp) and type(node.op) in _UNARYOPS:
+        return _UNARYOPS[type(node.op)](_eval_node(node.operand))
+    if isinstance(node, ast.BinOp) and type(node.op) in _BINOPS:
+        left = _eval_node(node.left)
+        right = _eval_node(node.right)
+        # 2**999999999 would sit there chewing memory, and nothing anyone
+        # searches for needs an exponent that big
+        if isinstance(node.op, ast.Pow) and abs(right) > 64:
+            raise ValueError('exponent too large')
+        return _BINOPS[type(node.op)](left, right)
+    raise ValueError('unsupported expression')
+
 # evaluate the expression
 def eval_operand(s):
     try:
-        v = eval(s)
+        v = _eval_node(ast.parse(s.strip(), mode='eval').body)
         py2_long = not PY3K and isinstance(v, long)
         if isinstance(v, int) or isinstance(v, float) or py2_long:
             return v

--- a/gui/org.scanmem.gameconqueror.policy.in.in
+++ b/gui/org.scanmem.gameconqueror.policy.in.in
@@ -5,7 +5,7 @@
 <policyconfig>
  <vendor>Scanmem</vendor>
  <vendor_url>https://github.com/scanmem/scanmem</vendor_url>
- <action id="org.freedesktop.gameconqueror.pkexec.run">
+ <action id="org.scanmem.gameconqueror.pkexec.run">
     <_description>Run Game Conqueror</_description>
     <_message>Authentication is required to run Game Conqueror</_message>
     <icon_name>GameConqueror</icon_name>

--- a/handlers.c
+++ b/handlers.c
@@ -713,21 +713,31 @@ bool handler__lregions(globals_t * vars, char **argv, unsigned argc)
 bool handler__operators(globals_t * vars, char **argv, unsigned argc)
 {
     uservalue_t val;
+    uservalue_t val2;
     scan_match_type_t m;
+    /* `^` is the only operator taking two values */
+    bool is_xor = (strcmp(argv[0], "^") == 0);
+
+    zero_uservalue(&val2);
+
+    if (argc > 3 || (argc == 3 && !is_xor))
+    {
+        show_error("too many values specified, see `help %s`", argv[0]);
+        return false;
+    }
 
     if (argc == 1)
     {
         zero_uservalue(&val);
     }
-    else if (argc > 2)
-    {
-        show_error("too many values specified, see `help %s`", argv[0]);
-        return false;
-    }
     else
     {
         if (!parse_uservalue_number(argv[1], &val)) {
             show_error("bad value specified, see `help %s`", argv[0]);
+            return false;
+        }
+        if (argc == 3 && !parse_uservalue_number(argv[2], &val2)) {
+            show_error("bad 2nd value specified, see `help %s`", argv[0]);
             return false;
         }
     }
@@ -757,6 +767,18 @@ bool handler__operators(globals_t * vars, char **argv, unsigned argc)
     {
         m = (argc == 1) ? MATCHDECREASED : MATCHDECREASEDBY;
     }
+    else if (is_xor)
+    {
+        if (argc == 1) {
+            show_error("`^' needs one or two values, see `help ^`.\n");
+            return false;
+        }
+        /* the scan compares against a single value, so fold the pair down to
+           the one thing it is looking for: old ^ new */
+        if (argc == 3)
+            xor_uservalue(&val, &val2);
+        m = MATCHXORBY;
+    }
     else
     {
         show_error("unrecognized operator seen at handler_operators: \"%s\".\n", argv[0]);
@@ -783,7 +805,8 @@ bool handler__operators(globals_t * vars, char **argv, unsigned argc)
             m == MATCHDECREASED   ||
             m == MATCHINCREASED   ||
             m == MATCHDECREASEDBY ||
-            m == MATCHINCREASEDBY )
+            m == MATCHINCREASEDBY ||
+            m == MATCHXORBY       )
         {
             show_error("cannot use that search without matches\n");
             return false;

--- a/handlers.c
+++ b/handlers.c
@@ -551,6 +551,7 @@ bool handler__reset(globals_t * vars, char **argv, unsigned argc)
         }
         vars->scan_progress = 0;
         if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
+        sm_history_clear();
         return true;
     }
 
@@ -1742,6 +1743,26 @@ bool handler__read(globals_t * vars, char **argv, unsigned argc)
     return true;
 }
 
+bool handler__undo(globals_t * vars, char **argv, unsigned argc)
+{
+    USEPARAMS();
+    if (argc != 1) {
+        show_error("bad arguments, see `help undo`.\n");
+        return false;
+    }
+    return sm_undo_scan();
+}
+
+bool handler__redo(globals_t * vars, char **argv, unsigned argc)
+{
+    USEPARAMS();
+    if (argc != 1) {
+        show_error("bad arguments, see `help redo`.\n");
+        return false;
+    }
+    return sm_redo_scan();
+}
+
 bool handler__option(globals_t * vars, char **argv, unsigned argc)
 {
     /* this might need to change */
@@ -1762,6 +1783,25 @@ bool handler__option(globals_t * vars, char **argv, unsigned argc)
             show_error("bad value for scan_data_type, see `help option`.\n");
             return false;
         }
+    }
+    else if (strcasecmp(argv[1], "undo_limit") == 0)
+    {
+        char *end = NULL;
+        unsigned long n;
+
+        errno = 0;
+        n = strtoul(argv[2], &end, 10);
+        /* strtoul happily wraps a leading '-', so reject the sign outright */
+        if (errno != 0 || end == argv[2] || *end != '\0'
+            || argv[2][0] == '-' || n > USHRT_MAX) {
+            show_error("undo_limit must be between 0 and %u, see `help option`.\n",
+                       (unsigned)USHRT_MAX);
+            return false;
+        }
+        vars->options.undo_limit = (unsigned short) n;
+        /* shrinking the limit must drop what no longer fits */
+        if (n == 0)
+            sm_history_clear();
     }
     else if (strcasecmp(argv[1], "region_scan_level") == 0)
     {

--- a/handlers.c
+++ b/handlers.c
@@ -2008,6 +2008,21 @@ bool handler__option(globals_t * vars, char **argv, unsigned argc)
         if (n == 0)
             sm_history_clear();
     }
+    else if (strcasecmp(argv[1], "alignment") == 0)
+    {
+        char *end = NULL;
+        unsigned long n;
+
+        errno = 0;
+        n = strtoul(argv[2], &end, 10);
+        /* powers of two only, anything else is not an alignment */
+        if (errno != 0 || end == argv[2] || *end != '\0' || argv[2][0] == '-'
+            || n == 0 || n > 8 || (n & (n - 1)) != 0) {
+            show_error("alignment must be 1, 2, 4 or 8, see `help option`.\n");
+            return false;
+        }
+        vars->options.alignment = (unsigned short) n;
+    }
     else if (strcasecmp(argv[1], "region_scan_level") == 0)
     {
         if (strcmp(argv[2], "1") == 0) {vars->options.region_scan_level = REGION_HEAP_STACK_EXECUTABLE; }

--- a/handlers.c
+++ b/handlers.c
@@ -522,12 +522,31 @@ bool handler__delete(globals_t * vars, char **argv, unsigned argc)
 
 bool handler__reset(globals_t * vars, char **argv, unsigned argc)
 {
-    USEPARAMS();
+    bool keep_regions = false;
+
+    if (argc > 2) {
+        show_error("bad arguments, see `help reset`.\n");
+        return false;
+    }
+
+    if (argc == 2) {
+        if (strcmp(argv[1], "keep-regions") != 0) {
+            show_error("unrecognised argument `%s', see `help reset`.\n", argv[1]);
+            return false;
+        }
+        keep_regions = true;
+    }
 
     /* reset scan progress */
     vars->scan_progress = 0;
 
     if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
+
+    /* regions come straight out of the maps file, so rereading them means
+       parsing the whole thing again. skip that when the caller only wanted
+       the matches gone and the target has not been re-executed. */
+    if (keep_regions)
+        return true;
 
     /* refresh list of regions */
     l_destroy(vars->regions);

--- a/handlers.c
+++ b/handlers.c
@@ -1626,6 +1626,19 @@ static inline scan_data_type_t parse_scan_data_type(const char *str)
         (strcasecmp(str, "integer64") == 0))
         return INTEGER64;
 
+    /* Unsigned ints. Same width, and the scan itself is sign agnostic (the
+       match flags carry both), but GameConqueror offers these names in its
+       type dropdown and the parser did not know them, so `write uint8 ...`
+       was rejected and the value silently never reached the target (#359). */
+    if ((strcasecmp(str, "u8") == 0)  || (strcasecmp(str, "uint8") == 0))
+        return INTEGER8;
+    if ((strcasecmp(str, "u16") == 0) || (strcasecmp(str, "uint16") == 0))
+        return INTEGER16;
+    if ((strcasecmp(str, "u32") == 0) || (strcasecmp(str, "uint32") == 0))
+        return INTEGER32;
+    if ((strcasecmp(str, "u64") == 0) || (strcasecmp(str, "uint64") == 0))
+        return INTEGER64;
+
     /* Floats */
     if ((strcasecmp(str, "f32") == 0) || (strcasecmp(str, "float32") == 0))
         return FLOAT32;
@@ -1639,6 +1652,16 @@ static inline scan_data_type_t parse_scan_data_type(const char *str)
 
     /* Not a valid type */
     return (scan_data_type_t)(-1);
+}
+
+/* Width comes from parse_scan_data_type, but write and read still have to
+   know whether the user meant it signed, since that picks the conversion. */
+static inline bool is_unsigned_type_name(const char *str)
+{
+    return (strcasecmp(str, "u8")  == 0) || (strcasecmp(str, "uint8")  == 0)
+        || (strcasecmp(str, "u16") == 0) || (strcasecmp(str, "uint16") == 0)
+        || (strcasecmp(str, "u32") == 0) || (strcasecmp(str, "uint32") == 0)
+        || (strcasecmp(str, "u64") == 0) || (strcasecmp(str, "uint64") == 0);
 }
 
 /* write value_type address value */
@@ -1661,31 +1684,32 @@ bool handler__write(globals_t * vars, char **argv, unsigned argc)
     }
 
     scan_data_type_t st = parse_scan_data_type(argv[1]);
+    bool is_unsigned = is_unsigned_type_name(argv[1]);
 
     /* try int first */
     if (st == INTEGER8)
     {
         data_width = 1;
         datatype = 0;
-        fmt = "%"PRId8;
+        fmt = is_unsigned ? "%"PRIu8 : "%"PRId8;
     }
     else if (st == INTEGER16)
     {
         data_width = 2;
         datatype = 0;
-        fmt = "%"PRId16;
+        fmt = is_unsigned ? "%"PRIu16 : "%"PRId16;
     }
     else if (st == INTEGER32)
     {
         data_width = 4;
         datatype = 0;
-        fmt = "%"PRId32;
+        fmt = is_unsigned ? "%"PRIu32 : "%"PRId32;
     }
     else if (st == INTEGER64)
     {
         data_width = 8;
         datatype = 0;
-        fmt = "%"PRId64;
+        fmt = is_unsigned ? "%"PRIu64 : "%"PRId64;
     }
     else if (st == FLOAT32)
     {
@@ -1848,6 +1872,7 @@ bool handler__read(globals_t * vars, char **argv, unsigned argc)
     void *addr;
     char *endptr;
     scan_data_type_t st;
+    bool is_unsigned;
 
     if (argc != 3)
     {
@@ -1862,6 +1887,7 @@ bool handler__read(globals_t * vars, char **argv, unsigned argc)
     }
 
     st = parse_scan_data_type(argv[1]);
+    is_unsigned = is_unsigned_type_name(argv[1]);
 
     switch (st)
     {
@@ -1897,10 +1923,22 @@ bool handler__read(globals_t * vars, char **argv, unsigned argc)
 
     switch (st)
     {
-    case INTEGER8:  printf("%"PRId8"\n",  buf.i8);  break;
-    case INTEGER16: printf("%"PRId16"\n", buf.i16); break;
-    case INTEGER32: printf("%"PRId32"\n", buf.i32); break;
-    case INTEGER64: printf("%"PRId64"\n", buf.i64); break;
+    case INTEGER8:
+        if (is_unsigned) printf("%"PRIu8"\n",  (uint8_t) buf.i8);
+        else             printf("%"PRId8"\n",  buf.i8);
+        break;
+    case INTEGER16:
+        if (is_unsigned) printf("%"PRIu16"\n", (uint16_t)buf.i16);
+        else             printf("%"PRId16"\n", buf.i16);
+        break;
+    case INTEGER32:
+        if (is_unsigned) printf("%"PRIu32"\n", (uint32_t)buf.i32);
+        else             printf("%"PRId32"\n", buf.i32);
+        break;
+    case INTEGER64:
+        if (is_unsigned) printf("%"PRIu64"\n", (uint64_t)buf.i64);
+        else             printf("%"PRId64"\n", buf.i64);
+        break;
     case FLOAT32:   printf("%f\n",        buf.f32); break;
     case FLOAT64:   printf("%lf\n",       buf.f64); break;
     default:

--- a/handlers.c
+++ b/handlers.c
@@ -537,35 +537,20 @@ bool handler__reset(globals_t * vars, char **argv, unsigned argc)
         keep_regions = true;
     }
 
-    /* reset scan progress */
-    vars->scan_progress = 0;
-
-    if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
-
     /* regions come straight out of the maps file, so rereading them means
        parsing the whole thing again. skip that when the caller only wanted
        the matches gone and the target has not been re-executed. */
-    if (keep_regions)
+    if (keep_regions) {
+        if (vars->scan_in_progress) {
+            show_error("cannot reset while a scan is in progress.\n");
+            return false;
+        }
+        vars->scan_progress = 0;
+        if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
         return true;
-
-    /* refresh list of regions */
-    l_destroy(vars->regions);
-
-    /* create a new linked list of regions */
-    if ((vars->regions = l_init()) == NULL) {
-        show_error("sorry, there was a problem allocating memory.\n");
-        return false;
     }
 
-    /* read in maps if a pid is known */
-    if (vars->target && sm_readmaps(vars->target, vars->regions, vars->options.region_scan_level) != true) {
-        show_error("sorry, there was a problem getting a list of regions to search.\n");
-        show_warn("the pid may be invalid, or you don't have permission.\n");
-        vars->target = 0;
-        return false;
-    }
-
-    return true;
+    return sm_reset();
 }
 
 bool handler__pid(globals_t * vars, char **argv, unsigned argc)

--- a/handlers.c
+++ b/handlers.c
@@ -1277,6 +1277,173 @@ bool handler__watch(globals_t * vars, char **argv, unsigned argc)
     }
 }
 
+/* Cap so a typo like `memdiff 0 99999999999` does not try to allocate three
+   copies of it. Three buffers of this is 3MB, which is plenty to watch. */
+#define MEMDIFF_MAX_LEN (1 << 20)
+#define MEMDIFF_CHANGED "\033[0;32m"   /* moved since the previous read */
+#define MEMDIFF_MOVED   "\033[0;33m"   /* same as last read, but not the start */
+#define MEMDIFF_RESET   "\033[0m"
+
+/* memdiff <address> <length> [list]
+ * Re-read a region once a second and show what moved. */
+bool handler__memdiff(globals_t * vars, char **argv, unsigned argc)
+{
+    void *addr;
+    char *endptr;
+    unsigned char *buf = NULL, *prev = NULL, *start = NULL;
+    bool colour;
+    size_t len, i, j;
+    /* volatile: these live across the sigsetjmp below, see handler__set */
+    volatile bool list_mode = false;
+    volatile bool ret = false;
+
+    if (argc < 3 || argc > 4)
+    {
+        show_error("bad arguments, see `help memdiff`.\n");
+        return false;
+    }
+
+    if (vars->target == 0)
+    {
+        show_error("no target set, type `help pid`.\n");
+        return false;
+    }
+
+    /* check address */
+    errno = 0;
+    addr = (void *) strtoull(argv[1], &endptr, 16);
+    if ((errno != 0) || (endptr == argv[1]) || (*endptr != '\0'))
+    {
+        show_error("bad address, see `help memdiff`.\n");
+        return false;
+    }
+
+    /* check length */
+    errno = 0;
+    len = strtoul(argv[2], &endptr, 0);
+    if ((errno != 0) || (endptr == argv[2]) || (*endptr != '\0')
+        || (len == 0) || (len > MEMDIFF_MAX_LEN))
+    {
+        show_error("bad length, must be 1 to %d, see `help memdiff`.\n",
+                   MEMDIFF_MAX_LEN);
+        return false;
+    }
+
+    if (argc == 4)
+    {
+        if (strcmp(argv[3], "list") != 0)
+        {
+            show_error("bad argument `%s', see `help memdiff`.\n", argv[3]);
+            return false;
+        }
+        list_mode = true;
+    }
+
+    /* escape codes would land in the pipe as bytes, and the gui parses this
+       output, so colour only when a person is actually watching */
+    colour = isatty(STDOUT_FILENO) && (vars->options.backend == 0);
+
+    buf = malloc(len);
+    prev = malloc(len);
+    start = malloc(len);
+    if (buf == NULL || prev == NULL || start == NULL)
+    {
+        show_error("memory allocation failed.\n");
+        goto out;
+    }
+
+    /* seed both references from one read, so the first frame shows no change
+       rather than everything having "changed" from zeroed memory */
+    if (!sm_read_array(vars->target, addr, buf, len))
+    {
+        show_error("read memory failed.\n");
+        goto out;
+    }
+    memcpy(prev, buf, len);
+    memcpy(start, buf, len);
+
+    if (INTERRUPTABLE())
+    {
+        /* control returns here when interrupted */
+        sm_detach(vars->target);
+        ENDINTERRUPTABLE();
+        ret = true;
+        goto out;
+    }
+
+    while (true)
+    {
+        if (sm_process_is_dead(vars->target))
+        {
+            vars->target = 0;
+            show_info("target process died, stopping memdiff.\n");
+            break;
+        }
+
+        if (!sm_read_array(vars->target, addr, buf, len))
+        {
+            show_error("read memory failed.\n");
+            ENDINTERRUPTABLE();
+            goto out;
+        }
+
+        if (list_mode)
+        {
+            for (i = 0; i < len; ++i)
+                if (buf[i] != prev[i])
+                    printf("%p: 0x%02X => 0x%02X\n",
+                           (void *)((char *)addr + i), prev[i], buf[i]);
+        }
+        else
+        {
+            for (i = 0; i < len; i += 16)
+            {
+                size_t n = (len - i < 16) ? len - i : 16;
+
+                printf("%p: ", (void *)((char *)addr + i));
+                for (j = 0; j < 16; ++j)
+                {
+                    unsigned char c;
+
+                    if (j >= n) { printf("   "); continue; }
+
+                    c = buf[i + j];
+                    if (colour && c != prev[i + j])
+                        printf(MEMDIFF_CHANGED "%02X" MEMDIFF_RESET " ", c);
+                    else if (colour && c != start[i + j])
+                        printf(MEMDIFF_MOVED "%02X" MEMDIFF_RESET " ", c);
+                    else
+                        printf("%02X ", c);
+                }
+                if (vars->options.dump_with_ascii == 1)
+                {
+                    for (j = 0; j < n; ++j)
+                    {
+                        unsigned char c = buf[i + j];
+                        printf("%c", isprint(c) ? c : '.');
+                    }
+                }
+                printf("\n");
+            }
+            printf("\n");
+        }
+
+        fflush(stdout);
+        /* only now, so one frame's "changed" means changed since the frame
+           that was actually printed before it */
+        memcpy(prev, buf, len);
+        sleep(1);
+    }
+
+    ENDINTERRUPTABLE();
+    ret = true;
+out:
+    free(buf);
+    free(prev);
+    free(start);
+    return ret;
+}
+
 #include "licence.h"
 
 bool handler__show(globals_t * vars, char **argv, unsigned argc)

--- a/handlers.c
+++ b/handlers.c
@@ -1649,6 +1649,87 @@ retl:
     return ret;
 }
 
+/* read <value_type> <address>, the counterpart to write. `dump` already
+ * covers raw byte ranges, so this only does the numeric types. */
+bool handler__read(globals_t * vars, char **argv, unsigned argc)
+{
+    /* union rather than a malloc'd char buffer: gets the alignment right for
+       the 8 byte reads for free, and there is nothing to leak on error */
+    union {
+        int8_t   i8;
+        int16_t  i16;
+        int32_t  i32;
+        int64_t  i64;
+        float    f32;
+        double   f64;
+        uint8_t  bytes[8];
+    } buf;
+    int data_width;
+    void *addr;
+    char *endptr;
+    scan_data_type_t st;
+
+    if (argc != 3)
+    {
+        show_error("bad arguments, see `help read`.\n");
+        return false;
+    }
+
+    if (vars->target == 0)
+    {
+        show_error("no target set, type `help pid`.\n");
+        return false;
+    }
+
+    st = parse_scan_data_type(argv[1]);
+
+    switch (st)
+    {
+    case INTEGER8:  data_width = 1; break;
+    case INTEGER16: data_width = 2; break;
+    case INTEGER32: data_width = 4; break;
+    case INTEGER64: data_width = 8; break;
+    case FLOAT32:   data_width = 4; break;
+    case FLOAT64:   data_width = 8; break;
+    default:
+        show_error("bad data_type, see `help read`.\n");
+        return false;
+    }
+
+    errno = 0;
+    addr = (void *)strtoll(argv[2], &endptr, 16);
+    if ((errno != 0) || (endptr == argv[2]) || (*endptr != '\0'))
+    {
+        show_error("bad address, see `help read`.\n");
+        return false;
+    }
+
+    if (!sm_read_array(vars->target, addr, buf.bytes, data_width))
+    {
+        show_error("read memory failed.\n");
+        return false;
+    }
+
+    /* write swaps on the way in when this option is set, so undo it here or
+       read would not round trip what write just put there */
+    if (1 < data_width && vars->options.reverse_endianness)
+        swap_bytes_var(buf.bytes, data_width);
+
+    switch (st)
+    {
+    case INTEGER8:  printf("%"PRId8"\n",  buf.i8);  break;
+    case INTEGER16: printf("%"PRId16"\n", buf.i16); break;
+    case INTEGER32: printf("%"PRId32"\n", buf.i32); break;
+    case INTEGER64: printf("%"PRId64"\n", buf.i64); break;
+    case FLOAT32:   printf("%f\n",        buf.f32); break;
+    case FLOAT64:   printf("%lf\n",       buf.f64); break;
+    default:
+        assert(false);
+    }
+
+    return true;
+}
+
 bool handler__option(globals_t * vars, char **argv, unsigned argc)
 {
     /* this might need to change */

--- a/handlers.c
+++ b/handlers.c
@@ -4,7 +4,7 @@
     Copyright (C) 2006,2007,2009 Tavis Ormandy <taviso@sdf.lonestar.org>
     Copyright (C) 2009           Eli Dupree <elidupree@charter.net>
     Copyright (C) 2009,2010      WANG Lu <coolwanglu@gmail.com>
-    Copyright (C) 2014-2016      Sebastian Parschauer <s.parschauer@gmx.de>
+    Copyright (C) 2014-2019      Sebastian Parschauer <s.parschauer@gmx.de>
 
     This file is part of libscanmem.
 
@@ -433,7 +433,11 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc)
                 if (address_ul < region_start + region->size &&
                   address_ul >= region_start) {
                     region_id = region->id;
-                    match_off = address_ul - region->load_addr;
+                    if (region->type == REGION_TYPE_STACK &&
+                      region->load_addr > region_start)
+                        match_off = region->load_addr - address_ul;
+                    else
+                        match_off = address_ul - region->load_addr;
                     region_type = region_type_names[region->type];
                     break;
                 }

--- a/handlers.h
+++ b/handlers.h
@@ -364,9 +364,26 @@ bool handler__write(globals_t *vars, char **argv, unsigned argc);
 
 bool handler__read(globals_t *vars, char **argv, unsigned argc);
 
+#define UNDO_SHRTDOC "undo the last scan"
+#define UNDO_LONGDOC "usage: undo\n" \
+                "\n" \
+                "Put the match set back to what it was before the last scan.\n" \
+                "Off unless `option undo_limit' is set to how many scans you want to\n" \
+                "be able to step back through. Each remembered scan holds a full copy\n" \
+                "of its match set, so a large limit on an early scan costs real memory.\n"
+
+#define REDO_SHRTDOC "redo a scan undone with `undo`"
+#define REDO_LONGDOC "usage: redo\n" \
+                "\n" \
+                "Step forward again after `undo`. Running a new scan discards anything\n" \
+                "that could have been redone.\n"
+
+bool handler__undo(globals_t *vars, char **argv, unsigned argc);
+bool handler__redo(globals_t *vars, char **argv, unsigned argc);
+
 #define OPTION_COMPLETE "scan_data_type{number,int,float," VALUE_TYPES \
     "},region_scan_level{1,2,3,4},dump_with_ascii{0,1},endianness{0,1,2}," \
-    "noptrace{0,1},threads"
+    "noptrace{0,1},threads,undo_limit"
 #define OPTION_SHRTDOC "set runtime options of scanmem, see `help option`"
 #define OPTION_LONGDOC "usage: option <option_name> <option_value>\n" \
                  "\n" \
@@ -411,6 +428,16 @@ bool handler__read(globals_t *vars, char **argv, unsigned argc);
                  "\tpossible values:\n" \
                  "\t0:\tone per online CPU\n" \
                  "\tN:\texactly N threads, 1 to scan serially\n" \
+                 "\n" \
+                 "undo_limit\thow many scans `undo' can step back through\n" \
+                 "\t\t\tDefault:0\n" \
+                 "\n" \
+                 "\tEach remembered scan keeps a full copy of its match set, so\n" \
+                 "\tthis costs memory in proportion to how big those were.\n" \
+                 "\n" \
+                 "\tpossible values:\n" \
+                 "\t0:\tundo disabled, nothing is kept\n" \
+                 "\tN:\tremember the last N scans\n" \
                  "\n" \
                  "endianness\tendianness of data (used by: set, write and comparisons)\n" \
                  "\t\t\tDefault:0\n" \

--- a/handlers.h
+++ b/handlers.h
@@ -336,6 +336,23 @@ bool handler__dump(globals_t *vars, char **argv, unsigned argc);
 
 bool handler__write(globals_t *vars, char **argv, unsigned argc);
 
+#define READ_COMPLETE VALUE_TYPES
+#define READ_SHRTDOC "read the value at a specific memory location"
+#define READ_LONGDOC "usage: read <value_type> <address>\n" \
+                "\n" \
+                "Read a <value_type> from <address> and print it.\n" \
+                "<value_type> should be one of:\n" \
+                "\tint{8|16|32|64} (or i{8|16|32|64} for short)\n" \
+                "\tfloat{32|64} (or f{32|64} for short)\n" \
+                "\n" \
+                "Use `dump` for raw byte ranges and strings.\n" \
+                "\n" \
+                "Example:\n" \
+                "\tread i16 60103e\n" \
+                "\tread float32 60103e\n"
+
+bool handler__read(globals_t *vars, char **argv, unsigned argc);
+
 #define OPTION_COMPLETE "scan_data_type{number,int,float," VALUE_TYPES \
     "},region_scan_level{1,2,3,4},dump_with_ascii{0,1},endianness{0,1,2}," \
     "noptrace{0,1},threads"

--- a/handlers.h
+++ b/handlers.h
@@ -310,6 +310,25 @@ bool handler__shell(globals_t *vars, char **argv, unsigned argc);
 
 bool handler__watch(globals_t *vars, char **argv, unsigned argc);
 
+#define MEMDIFF_SHRTDOC "watch a memory region and show what changes"
+#define MEMDIFF_LONGDOC "usage: memdiff <address> <length> [list]\n" \
+                "\n" \
+                "Re-read <length> bytes at <address> once a second and show what moved.\n" \
+                "Interrupt with ^C to stop.\n" \
+                "\n" \
+                "Default output is a hex table. On a terminal, green marks a byte that\n" \
+                "changed since the previous read and yellow one that is unchanged since\n" \
+                "the previous read but differs from where it started. Colour is left out\n" \
+                "when the output is not a terminal.\n" \
+                "\n" \
+                "With <list>, print only the bytes that changed, one per line.\n" \
+                "\n" \
+                "Examples:\n" \
+                "\tmemdiff 2acbbd0 16\n" \
+                "\tmemdiff 2acbbd0 128 list\n"
+
+bool handler__memdiff(globals_t *vars, char **argv, unsigned argc);
+
 /*XXX: improve this */
 #define SHOW_COMPLETE "copying,warranty,version"
 #define SHOW_SHRTDOC "display information about scanmem."

--- a/handlers.h
+++ b/handlers.h
@@ -405,7 +405,7 @@ bool handler__redo(globals_t *vars, char **argv, unsigned argc);
 
 #define OPTION_COMPLETE "scan_data_type{number,int,float," VALUE_TYPES \
     "},region_scan_level{1,2,3,4},dump_with_ascii{0,1},endianness{0,1,2}," \
-    "noptrace{0,1},threads,undo_limit"
+    "noptrace{0,1},threads,undo_limit,alignment{1,2,4,8}"
 #define OPTION_SHRTDOC "set runtime options of scanmem, see `help option`"
 #define OPTION_LONGDOC "usage: option <option_name> <option_value>\n" \
                  "\n" \
@@ -423,6 +423,16 @@ bool handler__redo(globals_t *vars, char **argv, unsigned argc);
                  "\tfloat{32|64}:\t\tfloat of given width\n" \
                  "\tbytearray:\t\tan array of bytes\n" \
                  "\tstring:\t\t\tstring\n" \
+                 "\n" \
+                 "alignment\t\tonly look at addresses that are a multiple of\n" \
+                 "\t\t\tthis, which is how a compiler lays variables out\n" \
+                 "\t\t\tanyway. 4 for a 32 bit value cuts the work to a\n" \
+                 "\t\t\tquarter. A value the compiler did not align that\n" \
+                 "\t\t\tway is missed, so drop back to 1 if a search that\n" \
+                 "\t\t\tshould have found something comes back empty.\n" \
+                 "\t\t\tDefault:1\n" \
+                 "\n" \
+                 "\tPossible Values: 1, 2, 4, 8\n" \
                  "\n" \
                  "region_scan_level\tspecify which regions should be scanned\n" \
                  "\t\t\tDefault:2\n" \

--- a/handlers.h
+++ b/handlers.h
@@ -171,6 +171,7 @@ bool handler__lregions(globals_t *vars, char **argv, unsigned argc);
 #define CHANGED_SHRTDOC     "match values that have changed or different from some number"
 #define INCREASED_SHRTDOC   "match values that have increased at all or by some number"
 #define DECREASED_SHRTDOC   "match values that have decreased at all or by some number"
+#define XOR_SHRTDOC         "match values whose change equals a given xor"
 
 #define GREATERTHAN_LONGDOC "usage: > [n]\n" \
                 "If n is given, match values that are greater than n.\n" \
@@ -200,6 +201,16 @@ bool handler__lregions(globals_t *vars, char **argv, unsigned argc);
                 "Otherwise match all values that have decreased. (same as `<`)\n" \
                 "You can use this in conjunction with `snapshot` if you never know its value."
 
+
+#define XOR_LONGDOC "usage: ^ n [m]\n" \
+                "Match values where the old value xored with the current value equals n,\n" \
+                "or equals n^m if m is given.\n" \
+                "\n" \
+                "Use this when the target stores a value xored with a key you do not know.\n" \
+                "If the plaintext went from n to m, the stored words differ by exactly\n" \
+                "n^m whatever the key is, because the key cancels out.\n" \
+                "\n" \
+                "Integer types only. Cannot be used for the first scan.\n"
 
 bool handler__operators(globals_t *vars, char **argv, unsigned argc);
 

--- a/handlers.h
+++ b/handlers.h
@@ -113,11 +113,17 @@ bool handler__list(globals_t *vars, char **argv, unsigned argc);
 
 bool handler__delete(globals_t *vars, char **argv, unsigned argc);
 
+#define RESET_COMPLETE "keep-regions"
 #define RESET_SHRTDOC "forget all matches, and reinitialise regions"
-#define RESET_LONGDOC "usage: reset\n" \
+#define RESET_LONGDOC "usage: reset [keep-regions]\n" \
                 "Forget all matches and regions, and reread regions from the relevant\n" \
                 "maps file. Useful if you have made an error, or want to find a new\n" \
-                "variable.\n"
+                "variable.\n" \
+                "\n" \
+                "With <keep-regions>, forget the matches but keep the region list you\n" \
+                "already have instead of rereading the maps file. Faster on a process\n" \
+                "with many mappings. Do not use it if the target may have mapped or\n" \
+                "unmapped memory since the regions were read.\n"
 
 bool handler__reset(globals_t *vars, char **argv, unsigned argc);
 

--- a/handlers.h
+++ b/handlers.h
@@ -346,7 +346,8 @@ bool handler__show(globals_t *vars, char **argv, unsigned argc);
     
 bool handler__dump(globals_t *vars, char **argv, unsigned argc);
 
-#define VALUE_TYPES "int8,int16,int32,int64,float32,float64,bytearray,string"
+#define VALUE_TYPES "int8,uint8,int16,uint16,int32,uint32,int64,uint64," \
+    "float32,float64,bytearray,string"
 #define WRITE_COMPLETE VALUE_TYPES
 #define WRITE_SHRTDOC "change the value of a specific memory location"
 #define WRITE_LONGDOC "usage: write <value_type> <address> <value>\n" \
@@ -354,6 +355,7 @@ bool handler__dump(globals_t *vars, char **argv, unsigned argc);
                 "Write <value> into <address>\n" \
                 "<value_type> should be one of:\n" \
                 "\tint{8|16|32|64} (or i{8|16|32|64} for short)\n" \
+                "\tuint{8|16|32|64} (or u{8|16|32|64} for short)\n" \
                 "\tfloat{32|64} (or f{32|64} for short)\n" \
                 "\tbytearray\n" \
                 "\tstring\n" \
@@ -373,6 +375,7 @@ bool handler__write(globals_t *vars, char **argv, unsigned argc);
                 "Read a <value_type> from <address> and print it.\n" \
                 "<value_type> should be one of:\n" \
                 "\tint{8|16|32|64} (or i{8|16|32|64} for short)\n" \
+                "\tuint{8|16|32|64} (or u{8|16|32|64} for short)\n" \
                 "\tfloat{32|64} (or f{32|64} for short)\n" \
                 "\n" \
                 "Use `dump` for raw byte ranges and strings.\n" \

--- a/interrupt.c
+++ b/interrupt.c
@@ -29,7 +29,7 @@
 
 sigjmp_buf jmpbuf;       /* used when aborting a command due to an interrupt */
 sighandler_t oldsig;     /* reinstalled before longjmp */
-unsigned intr_used;
+volatile sig_atomic_t intr_used;
 
 /* signal handler used to handle an interrupt during commands */
 void interrupted(int n)

--- a/interrupt.h
+++ b/interrupt.h
@@ -29,7 +29,7 @@
 
 extern sigjmp_buf jmpbuf;       /* used when aborting a command due to an interrupt */
 extern sighandler_t oldsig;     /* reinstalled before longjmp */
-extern unsigned intr_used;
+extern volatile sig_atomic_t intr_used;
 
 /* signal handler used to handle an interrupt during commands */
 void interrupted(int);

--- a/maps.c
+++ b/maps.c
@@ -4,7 +4,7 @@
     Copyright (C) 2006,2007,2009 Tavis Ormandy <taviso@sdf.lonestar.org>
     Copyright (C) 2009           Eli Dupree <elidupree@charter.net>
     Copyright (C) 2009,2010      WANG Lu <coolwanglu@gmail.com>
-    Copyright (C) 2014-2016      Sebastian Parschauer <s.parschauer@gmx.de>
+    Copyright (C) 2014-2019      Sebastian Parschauer <s.parschauer@gmx.de>
 
     This file is part of libscanmem.
 
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <stdbool.h>
 #include <unistd.h>
+#include <errno.h>
 
 #include "list.h"
 #include "maps.h"
@@ -40,6 +41,114 @@
 #include "show_message.h"
 
 const char *region_type_names[] = REGION_TYPE_NAMES;
+
+/*
+ * Calling strchr() is too expensive as it does not have a built-in.
+ * So avoid this function.
+ */
+#define STRCHR(__code)                           \
+do {                                             \
+    for (; ; epos++) {                           \
+        if (*epos == '\0')                       \
+            goto parse_err;                      \
+        __code                                   \
+    }                                            \
+} while (0)
+
+/*
+ * Read the stack end from /proc/$pid/stat
+ *
+ * The process name may contain spaces. This is rather an optional
+ * feature. So handle errors gracefully by falling back to the stack
+ * region start.
+ */
+static unsigned long
+get_stack_end(pid_t target, unsigned long start, unsigned long end)
+{
+    FILE *stat_file;
+    char stat_path[128];
+    char *line = NULL, *spos, *epos;  /* start and end positions */
+    size_t len = 0;
+    unsigned long stack_end = start;
+    /*
+     *  The stack end is the 28th value. So go to 27th space.
+     *  See "man 5 proc".
+     */
+    const int stack_end_idx = 27;
+    int i;
+
+    /* construct the stat file path */
+    snprintf(stat_path, sizeof(stat_path), "/proc/%u/stat", target);
+
+    /* attempt to open the stat file */
+    stat_file = fopen(stat_path, "r");
+    if (!stat_file) {
+        show_debug("failed to open stat file %s.\n", stat_path);
+        goto out;
+    }
+    /* read stat file */
+    if (getline(&line, &len, stat_file) < 0) {
+        if (line)
+            free(line);
+        fclose(stat_file);
+        show_debug("failed to read stat file %s.\n", stat_path);
+        goto out;
+    }
+
+    /* move to the end of the process name first */
+    epos = line;
+    STRCHR(
+        if (*epos == '(') {
+            epos++;
+            break;
+        }
+    );
+    STRCHR(
+        if (*epos == ')') {
+            epos++;
+            break;
+        }
+    );
+
+    /* get the stack end */
+    i = 1;
+    /* start at 1 due to space between pid and proc name */
+    STRCHR(
+        if (*epos == ' ') {
+            i++;
+            if (i == stack_end_idx) {
+                spos = ++epos;
+                break;
+            }
+        }
+    );
+    STRCHR(
+        if (*epos == ' ')
+            break;
+    );
+    *epos = '\0';
+    errno = 0;
+    stack_end = strtoul(spos, NULL, 10);
+    if (errno) {
+        stack_end = start;
+        goto parse_err;
+    }
+
+    free(line);
+    fclose(stat_file);
+
+    /* stack end needs to be in limits and in the upper half */
+    if (stack_end < start || stack_end > end ||
+            stack_end < (start + ((end - start) >> 1)))
+        stack_end = start;
+out:
+    return stack_end;
+parse_err:
+    free(line);
+    fclose(stat_file);
+    show_debug("failed to parse stat file.\n");
+    goto out;
+}
 
 bool sm_readmaps(pid_t target, list_t *regions, region_scan_level_t region_scan_level)
 {
@@ -237,6 +346,9 @@ bool sm_readmaps(pid_t target, list_t *regions, region_scan_level_t region_scan_
 
                 if (!useful)
                     continue;
+
+                if (type == REGION_TYPE_STACK)
+                    load_addr = get_stack_end(target, start, end);
 
                 /* allocate a new region structure */
                 if ((map = calloc(1, sizeof(region_t) + strlen(filename))) == NULL) {

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -2,5 +2,5 @@
 gui/GameConqueror.py
 gui/misc.py
 gui/org.scanmem.gameconqueror.desktop.in
-gui/org.freedesktop.gameconqueror.policy.in.in
+gui/org.scanmem.gameconqueror.policy.in.in
 gui/org.scanmem.gameconqueror.metainfo.xml.in

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,1 +1,1 @@
-gui/org.freedesktop.gameconqueror.policy.in
+gui/org.scanmem.gameconqueror.policy.in

--- a/ptrace.c
+++ b/ptrace.c
@@ -494,9 +494,9 @@ static inline uint16_t flags_to_memlength(scan_data_type_t scan_data_type, match
 
 /* This is the function that handles when you enter a value (or >, <, =) for the second or later time (i.e. when there's already a list of matches);
  * it reduces the list to those that still match. It returns false on failure to attach, detach, or reallocate memory, otherwise true. */
-bool sm_checkmatches(globals_t *vars,
-                     scan_match_type_t match_type,
-                     const uservalue_t *uservalue)
+static bool checkmatches_impl(globals_t *vars,
+                              scan_match_type_t match_type,
+                              const uservalue_t *uservalue)
 {
     matches_and_old_values_swath *reading_swath_index = vars->matches->swaths;
     matches_and_old_values_swath reading_swath = *reading_swath_index;
@@ -820,8 +820,22 @@ static unsigned scan_thread_count(const globals_t *vars)
 #endif
 }
 
+/* Thin wrapper so scan_in_progress is set on every path out, including the
+   early returns. sm_reset() refuses to free the matches while it is set. */
+bool sm_checkmatches(globals_t *vars,
+                     scan_match_type_t match_type,
+                     const uservalue_t *uservalue)
+{
+    bool ret;
+
+    vars->scan_in_progress = true;
+    ret = checkmatches_impl(vars, match_type, uservalue);
+    vars->scan_in_progress = false;
+    return ret;
+}
+
 /* sm_searchregions() performs an initial search of the process for values matching `uservalue` */
-bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const uservalue_t *uservalue)
+static bool searchregions_impl(globals_t *vars, scan_match_type_t match_type, const uservalue_t *uservalue)
 {
     matches_and_old_values_swath *writing_swath_index;
     unsigned long total_size = 0;
@@ -1097,6 +1111,17 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
 
     /* okay, detach */
     return sm_detach(vars->target);
+}
+
+/* see the note on sm_checkmatches above */
+bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const uservalue_t *uservalue)
+{
+    bool ret;
+
+    vars->scan_in_progress = true;
+    ret = searchregions_impl(vars, match_type, uservalue);
+    vars->scan_in_progress = false;
+    return ret;
 }
 
 /* Needs to support only ANYNUMBER types */

--- a/ptrace.c
+++ b/ptrace.c
@@ -529,6 +529,7 @@ static bool checkmatches_impl(globals_t *vars,
 
     size_t reading_iterator = 0;
     matches_and_old_values_swath *writing_swath_index = vars->matches->swaths;
+    matches_and_old_values_swath *new_swath;
     writing_swath_index->first_byte_in_child = NULL;
     writing_swath_index->number_of_bytes = 0;
 
@@ -579,8 +580,11 @@ static bool checkmatches_impl(globals_t *vars,
                - We can get away with assuming that the pointers will stay valid,
                  because as we never add more data to the array than there was before, it will not reallocate. */
 
-            writing_swath_index = add_element_fast(&(vars->matches), writing_swath_index, address,
+            new_swath = add_element_fast(&(vars->matches), writing_swath_index, address,
                                               get_u8b(memory_ptr), checkflags);
+            if (UNLIKELY(new_swath == NULL))
+                goto oom;
+            writing_swath_index = new_swath;
 
             ++vars->num_matches;
 
@@ -588,8 +592,11 @@ static bool checkmatches_impl(globals_t *vars,
         }
         else if (required_extra_bytes_to_record)
         {
-            writing_swath_index = add_element_fast(&(vars->matches), writing_swath_index, address,
+            new_swath = add_element_fast(&(vars->matches), writing_swath_index, address,
                                               get_u8b(memory_ptr), flags_empty);
+            if (UNLIKELY(new_swath == NULL))
+                goto oom;
+            writing_swath_index = new_swath;
             --required_extra_bytes_to_record;
         }
 
@@ -633,6 +640,7 @@ static bool checkmatches_impl(globals_t *vars,
         return false;
     }
 
+
     show_user("ok\n");
 
     /* tell front-end we've done */
@@ -642,6 +650,15 @@ static bool checkmatches_impl(globals_t *vars,
 
     /* okay, detach */
     return sm_detach(vars->target);
+
+oom:
+    /* the array is untouched and still ours, we just cannot record any more
+       into it. bail rather than write through the NULL, which is what used to
+       segfault on the next element (#307). */
+    ENDINTERRUPTABLE();
+    show_error("out of memory recording matches, the match list is unchanged.\n");
+    sm_detach(vars->target);
+    return false;
 }
 
 
@@ -1051,11 +1068,25 @@ static bool searchregions_impl(globals_t *vars, scan_match_type_t match_type, co
                     continue;
 
                 for (j = 0; j < c->nrecs; j++) {
-                    writing_swath_index = add_element_fast(&(vars->matches),
+                    matches_and_old_values_swath *new_swath;
+
+                    new_swath = add_element_fast(&(vars->matches),
                             writing_swath_index,
                             (char *)c->region->start + c->offset + c->recs[j].off,
                             c->recs[j].old_value, c->recs[j].match_info);
+                    /* this is where #307 crashed: the array stops growing,
+                       add_element handed back NULL, and the next element
+                       dereferenced it. stop instead. */
+                    if (UNLIKELY(new_swath == NULL)) {
+                        show_error("out of memory recording matches, giving up "
+                                   "on this scan.\n");
+                        ok = false;
+                        break;
+                    }
+                    writing_swath_index = new_swath;
                 }
+                if (!ok)
+                    break;
                 vars->num_matches += c->matches;
                 done_bytes += c->owned;
 
@@ -1066,6 +1097,9 @@ static bool searchregions_impl(globals_t *vars, scan_match_type_t match_type, co
                     print_a_dot();
                 }
             }
+
+            if (!ok)
+                break;
 
             /* skip whatever is left of a region that would not read */
             if (dead_region && n && (region_t *)n->data == dead_region) {

--- a/ptrace.c
+++ b/ptrace.c
@@ -828,6 +828,8 @@ bool sm_checkmatches(globals_t *vars,
 {
     bool ret;
 
+    /* snapshot before we narrow, so undo restores the pre-scan set */
+    sm_history_record();
     vars->scan_in_progress = true;
     ret = checkmatches_impl(vars, match_type, uservalue);
     vars->scan_in_progress = false;
@@ -1118,6 +1120,8 @@ bool sm_searchregions(globals_t *vars, scan_match_type_t match_type, const userv
 {
     bool ret;
 
+    /* snapshot before we narrow, so undo restores the pre-scan set */
+    sm_history_record();
     vars->scan_in_progress = true;
     ret = searchregions_impl(vars, match_type, uservalue);
     vars->scan_in_progress = false;

--- a/ptrace.c
+++ b/ptrace.c
@@ -705,6 +705,7 @@ typedef struct {
     size_t owned;                      /* bytes this chunk is responsible for */
     const uservalue_t *uservalue;
     size_t maxlen;                     /* longest match the routine can return */
+    size_t align;                      /* only test addresses that are a multiple of this */
 
     scan_record *recs;                 /* what to hand to add_element, in order */
     size_t nrecs;
@@ -774,6 +775,10 @@ static void scan_chunk_run(scan_chunk *c)
     size_t limit = c->owned;
     size_t remaining;
     const uint8_t *mp8 = c->buf + head;
+    /* alignment is about where the variable sits in the target, so it has to
+     * be measured on the target address, not on our offset into the buffer */
+    uintptr_t addr = (uintptr_t)r->start + c->offset;
+    uintptr_t alignmask = c->align > 1 ? (uintptr_t)c->align - 1 : 0;
 
     if (c->offset >= valid_len)
         limit = 0;
@@ -782,12 +787,18 @@ static void scan_chunk_run(scan_chunk *c)
 
     remaining = valid_len - c->offset;
 
-    for (j = 0; j < limit; j++, remaining--, mp8++) {
+    for (j = 0; j < limit; j++, remaining--, mp8++, addr++) {
         const mem64_t *mp = (const mem64_t *)mp8;
         match_flags f = flags_empty;
         unsigned int ml;
 
-        ml = (*sm_scan_routine)(mp, remaining, NULL, c->uservalue, &f);
+        /* skipping the routine is the whole point of the option, but the
+         * bytes a match owns still have to be recorded below, old values are
+         * kept per byte and a wide match needs all of its own */
+        if (alignmask && (addr & alignmask))
+            ml = 0;
+        else
+            ml = (*sm_scan_routine)(mp, remaining, NULL, c->uservalue, &f);
 
         if (UNLIKELY(ml > 0)) {
             c->recs[c->nrecs].off = (uint32_t)j;
@@ -862,7 +873,7 @@ static bool searchregions_impl(globals_t *vars, scan_match_type_t match_type, co
     region_t *r;
     unsigned long total_scan_bytes = 0;
     scan_chunk *chunks = NULL;
-    size_t maxlen, bufsize, chunk_bytes;
+    size_t maxlen, bufsize, chunk_bytes, align;
     unsigned nthreads, t;
     bool ok = true;
     unsigned long done_bytes = 0;
@@ -917,6 +928,8 @@ static bool searchregions_impl(globals_t *vars, scan_match_type_t match_type, co
     vars->stop_flag = false;
 
     maxlen = scan_max_match_length(vars->options.scan_data_type, uservalue);
+    /* 0 would be a broken option value, treat anything odd as every byte */
+    align = vars->options.alignment > 1 ? vars->options.alignment : 1;
     nthreads = scan_thread_count(vars);
 
 #ifdef SCAN_CHUNK_BYTES
@@ -1007,6 +1020,7 @@ static bool searchregions_impl(globals_t *vars, scan_match_type_t match_type, co
                 chunks[batch].owned = MIN(chunk_bytes, r->size - cur_off);
                 chunks[batch].uservalue = uservalue;
                 chunks[batch].maxlen = maxlen;
+                chunks[batch].align = align;
                 cur_off += chunks[batch].owned;
                 batch++;
             }

--- a/scanmem.1
+++ b/scanmem.1
@@ -7,7 +7,6 @@ scanmem \- locate and modify variables in an executing process.
 .RB [options]
 .IR [target-program-pid]
 
-
 .SH DESCRIPTION
 .B scanmem
 is an interactive debugging utility that can be used to isolate the address of a variable
@@ -328,7 +327,6 @@ I enter how much gold I currently have (58 pieces) and let
 .B scanmem
 find the potential candidates.
 
-
 .nf
 > 58
 01/09 searching   0x79f000 -   0x7b0000..........ok
@@ -470,18 +468,6 @@ split across threads now, see the
 option, which helps in proportion to how many cores are free. Scanning still looks at
 every byte offset rather than assuming integers are aligned. Suggestions welcome.
 
-Building with clang at
-.B -O1
-or higher produces a working binary that scans incorrectly. It finds a
-handful of matches where gcc finds all of them. gcc is fine at every
-optimisation level and so is clang at
-.BR -O0 ,
-so build with gcc until this is tracked down. This is not new, it reproduces
-on releases well before the threaded scan, and it went unnoticed because the
-test suite used to assert nothing about scan results and CI only built with
-gcc. It is not strict aliasing, vectorisation, signed overflow, or the
-extern inline definitions; -fno-inline recovers part of it, so it looks like
-undefined behaviour somewhere that inlining exposes.
 
 The
 .B snapshot

--- a/scanmem.c
+++ b/scanmem.c
@@ -183,6 +183,8 @@ bool sm_init(void)
                        SHOW_LONGDOC, SHOW_COMPLETE);
     sm_registercommand("dump", handler__dump, vars->commands, DUMP_SHRTDOC,
                        DUMP_LONGDOC, NULL);
+    sm_registercommand("read", handler__read, vars->commands, READ_SHRTDOC,
+                       READ_LONGDOC, READ_COMPLETE);
     sm_registercommand("write", handler__write, vars->commands, WRITE_SHRTDOC,
                        WRITE_LONGDOC, WRITE_COMPLETE);
     sm_registercommand("option", handler__option, vars->commands, OPTION_SHRTDOC,

--- a/scanmem.c
+++ b/scanmem.c
@@ -69,7 +69,8 @@ globals_t sm_globals = {
         0,                      /* reverse_endianness */
         0,                      /* no_ptrace */
         0,                      /* threads, 0 = auto */
-    }
+    },
+    false,                      /* scan_in_progress */
 };
 
 /* signal handler - use async-signal safe functions ONLY! */
@@ -247,4 +248,43 @@ double sm_get_scan_progress(void)
 void sm_set_stop_flag(bool stop_flag)
 {
     sm_globals.stop_flag = stop_flag;
+}
+
+/* Drop all matches and reread the region list. Exposed so a front end can get
+   back to a clean state without going through the command parser.
+   Refuses while a scan is running: the scan owns vars->matches, so freeing it
+   underneath is a use after free rather than just a lost result. */
+bool sm_reset(void)
+{
+    globals_t *vars = &sm_globals;
+
+    if (vars->scan_in_progress) {
+        show_error("cannot reset while a scan is in progress.\n");
+        return false;
+    }
+
+    /* reset scan progress */
+    vars->scan_progress = 0;
+
+    if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
+
+    /* refresh list of regions */
+    l_destroy(vars->regions);
+
+    /* create a new linked list of regions */
+    if ((vars->regions = l_init()) == NULL) {
+        show_error("sorry, there was a problem allocating memory.\n");
+        return false;
+    }
+
+    /* read in maps if a pid is known */
+    if (vars->target && sm_readmaps(vars->target, vars->regions,
+                                    vars->options.region_scan_level) != true) {
+        show_error("sorry, there was a problem getting a list of regions to search.\n");
+        show_warn("the pid may be invalid, or you don't have permission.\n");
+        vars->target = 0;
+        return false;
+    }
+
+    return true;
 }

--- a/scanmem.c
+++ b/scanmem.c
@@ -34,6 +34,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "scanmem.h"
 #include "commands.h"
@@ -69,8 +70,11 @@ globals_t sm_globals = {
         0,                      /* reverse_endianness */
         0,                      /* no_ptrace */
         0,                      /* threads, 0 = auto */
+        0,                      /* undo_limit, 0 = undo disabled */
     },
     false,                      /* scan_in_progress */
+    NULL, 0,                    /* undo stack */
+    NULL, 0,                    /* redo stack */
 };
 
 /* signal handler - use async-signal safe functions ONLY! */
@@ -190,6 +194,10 @@ bool sm_init(void)
                        READ_LONGDOC, READ_COMPLETE);
     sm_registercommand("write", handler__write, vars->commands, WRITE_SHRTDOC,
                        WRITE_LONGDOC, WRITE_COMPLETE);
+    sm_registercommand("undo", handler__undo, vars->commands, UNDO_SHRTDOC,
+                       UNDO_LONGDOC, NULL);
+    sm_registercommand("redo", handler__redo, vars->commands, REDO_SHRTDOC,
+                       REDO_LONGDOC, NULL);
     sm_registercommand("option", handler__option, vars->commands, OPTION_SHRTDOC,
                        OPTION_LONGDOC, OPTION_COMPLETE);
 
@@ -214,6 +222,8 @@ void sm_cleanup(void)
     /* free matches array */
     if (sm_globals.matches)
         free(sm_globals.matches);
+
+    sm_history_clear();
 
     /* attempt to detach just in case */
     sm_detach(sm_globals.target);
@@ -252,6 +262,143 @@ void sm_set_stop_flag(bool stop_flag)
     sm_globals.stop_flag = stop_flag;
 }
 
+/* ---- scan undo/redo ---------------------------------------------------- */
+
+static void snapshot_free(scan_snapshot_t *s)
+{
+    free(s->matches);
+    s->matches = NULL;
+    s->num_matches = 0;
+}
+
+static bool snapshot_take(globals_t *vars, scan_snapshot_t *out)
+{
+    out->matches = NULL;
+    out->num_matches = vars->num_matches;
+
+    if (vars->matches == NULL)
+        return true;    /* nothing matched yet, an empty snapshot is valid */
+
+    out->matches = malloc(vars->matches->bytes_allocated);
+    if (out->matches == NULL)
+        return false;
+    memcpy(out->matches, vars->matches, vars->matches->bytes_allocated);
+    return true;
+}
+
+/* takes ownership of s->matches */
+static void snapshot_restore(globals_t *vars, scan_snapshot_t *s)
+{
+    free(vars->matches);
+    vars->matches = s->matches;
+    vars->num_matches = s->num_matches;
+    s->matches = NULL;
+}
+
+static void stack_clear(scan_snapshot_t **stack, unsigned *count)
+{
+    while (*count > 0)
+        snapshot_free(&(*stack)[--(*count)]);
+    free(*stack);
+    *stack = NULL;
+}
+
+static bool stack_push(scan_snapshot_t **stack, unsigned *count,
+                       const scan_snapshot_t *s)
+{
+    scan_snapshot_t *tmp = realloc(*stack, (*count + 1) * sizeof(**stack));
+
+    if (tmp == NULL)
+        return false;
+    *stack = tmp;
+    (*stack)[(*count)++] = *s;
+    return true;
+}
+
+/* Called just before a scan narrows the match set, so undo restores what was
+   there before it ran. Snapshotting beforehand rather than after is what
+   makes the very first scan undoable, back to no matches. */
+void sm_history_record(void)
+{
+    globals_t *vars = &sm_globals;
+    unsigned limit = vars->options.undo_limit;
+    scan_snapshot_t snap;
+
+    if (limit == 0)
+        return;
+
+    if (!snapshot_take(vars, &snap) ||
+        !stack_push(&vars->undo_stack, &vars->undo_count, &snap))
+    {
+        snapshot_free(&snap);
+        show_warn("not enough memory to save an undo state, undo will not "
+                  "reach past this scan.\n");
+        return;
+    }
+
+    /* drop the oldest once we are over the limit */
+    while (vars->undo_count > limit) {
+        snapshot_free(&vars->undo_stack[0]);
+        memmove(&vars->undo_stack[0], &vars->undo_stack[1],
+                (vars->undo_count - 1) * sizeof(*vars->undo_stack));
+        vars->undo_count--;
+    }
+
+    /* scanning forward throws away anything that was undone */
+    stack_clear(&vars->redo_stack, &vars->redo_count);
+}
+
+void sm_history_clear(void)
+{
+    stack_clear(&sm_globals.undo_stack, &sm_globals.undo_count);
+    stack_clear(&sm_globals.redo_stack, &sm_globals.redo_count);
+}
+
+/* shared by undo and redo, they differ only in which way the state moves */
+static bool history_step(scan_snapshot_t **from, unsigned *from_count,
+                         scan_snapshot_t **to, unsigned *to_count,
+                         const char *what)
+{
+    globals_t *vars = &sm_globals;
+    scan_snapshot_t cur;
+
+    if (vars->options.undo_limit == 0) {
+        show_error("undo is disabled, set `option undo_limit' first.\n");
+        return false;
+    }
+    if (vars->scan_in_progress) {
+        show_error("cannot %s while a scan is in progress.\n", what);
+        return false;
+    }
+    if (*from_count == 0) {
+        show_error("nothing to %s.\n", what);
+        return false;
+    }
+
+    /* stash where we are now so the opposite direction can get back */
+    if (!snapshot_take(vars, &cur) || !stack_push(to, to_count, &cur)) {
+        snapshot_free(&cur);
+        show_error("sorry, there was a problem allocating memory.\n");
+        return false;
+    }
+
+    snapshot_restore(vars, &(*from)[--(*from_count)]);
+    show_info("we currently have %ld matches.\n", vars->num_matches);
+    return true;
+}
+
+bool sm_undo_scan(void)
+{
+    return history_step(&sm_globals.undo_stack, &sm_globals.undo_count,
+                        &sm_globals.redo_stack, &sm_globals.redo_count, "undo");
+}
+
+bool sm_redo_scan(void)
+{
+    return history_step(&sm_globals.redo_stack, &sm_globals.redo_count,
+                        &sm_globals.undo_stack, &sm_globals.undo_count, "redo");
+}
+
 /* Drop all matches and reread the region list. Exposed so a front end can get
    back to a clean state without going through the command parser.
    Refuses while a scan is running: the scan owns vars->matches, so freeing it
@@ -269,6 +416,8 @@ bool sm_reset(void)
     vars->scan_progress = 0;
 
     if (vars->matches) { free(vars->matches); vars->matches = NULL; vars->num_matches = 0; }
+
+    sm_history_clear();
 
     /* refresh list of regions */
     l_destroy(vars->regions);

--- a/scanmem.c
+++ b/scanmem.c
@@ -136,7 +136,7 @@ bool sm_init(void)
     sm_registercommand("delete", handler__delete, vars->commands, DELETE_SHRTDOC,
                        DELETE_LONGDOC, NULL);
     sm_registercommand("reset", handler__reset, vars->commands, RESET_SHRTDOC,
-                       RESET_LONGDOC, NULL);
+                       RESET_LONGDOC, RESET_COMPLETE);
     sm_registercommand("pid", handler__pid, vars->commands, PID_SHRTDOC,
                        PID_LONGDOC, NULL);
     sm_registercommand("snapshot", handler__snapshot, vars->commands,

--- a/scanmem.c
+++ b/scanmem.c
@@ -116,11 +116,15 @@ bool sm_init(void)
     globals_t *vars = &sm_globals;
 
     /* before attaching to target, install signal handler to detach on error */
+    /* SIGSEGV is deliberately not caught. Trapping it and calling _exit()
+       swallowed the kernel's message and stopped a core dump being written,
+       which is exactly what you need when scanmem is the thing that crashed
+       (#307). The tracee is released when the tracer dies anyway, so there
+       was nothing to clean up that the kernel does not already do. */
     if (vars->options.debug == 0) /* in debug mode, let it crash and see the core dump */
     {
         (void) signal(SIGHUP, sighandler);
         (void) signal(SIGINT, sighandler);
-        (void) signal(SIGSEGV, sighandler);
         (void) signal(SIGABRT, sighandler);
         (void) signal(SIGILL, sighandler);
         (void) signal(SIGFPE, sighandler);

--- a/scanmem.c
+++ b/scanmem.c
@@ -150,6 +150,8 @@ bool sm_init(void)
                        LREGIONS_SHRTDOC, LREGIONS_LONGDOC, NULL);
     sm_registercommand("version", handler__version, vars->commands,
                        VERSION_SHRTDOC, VERSION_LONGDOC, NULL);
+    sm_registercommand("^", handler__operators, vars->commands, XOR_SHRTDOC,
+                       XOR_LONGDOC, NULL);
     sm_registercommand("=", handler__operators, vars->commands, NOTCHANGED_SHRTDOC,
                        NOTCHANGED_LONGDOC, NULL);
     sm_registercommand("!=", handler__operators, vars->commands, CHANGED_SHRTDOC,

--- a/scanmem.c
+++ b/scanmem.c
@@ -186,6 +186,8 @@ bool sm_init(void)
                        NULL);
     sm_registercommand("watch", handler__watch, vars->commands, WATCH_SHRTDOC,
                        WATCH_LONGDOC, NULL);
+    sm_registercommand("memdiff", handler__memdiff, vars->commands,
+                       MEMDIFF_SHRTDOC, MEMDIFF_LONGDOC, NULL);
     sm_registercommand("show", handler__show, vars->commands, SHOW_SHRTDOC,
                        SHOW_LONGDOC, SHOW_COMPLETE);
     sm_registercommand("dump", handler__dump, vars->commands, DUMP_SHRTDOC,

--- a/scanmem.h
+++ b/scanmem.h
@@ -37,6 +37,13 @@
 #include "targetmem.h"
 
 
+/* one saved match set, for undo/redo. matches is a single flat allocation,
+   so a memcpy of bytes_allocated is a full deep copy. */
+typedef struct {
+    matches_and_old_values_array *matches;
+    unsigned long num_matches;
+} scan_snapshot_t;
+
 /* global settings */
 typedef struct {
     unsigned exit:1;
@@ -62,10 +69,18 @@ typedef struct {
         unsigned short reverse_endianness;
         unsigned short no_ptrace;
         unsigned short threads;    /* 0 means pick from online CPUs */
+        unsigned short undo_limit; /* 0 disables scan undo entirely */
     } options;
     /* set while a scan owns vars->matches. appended at the end of the struct
        on purpose so existing member offsets do not move. */
     volatile bool scan_in_progress;
+    /* scan undo/redo. Appended so existing member offsets stay put. Each
+       entry holds a whole copy of the match set, which is why this is off
+       by default rather than sized by guesswork. */
+    scan_snapshot_t *undo_stack;
+    unsigned undo_count;
+    scan_snapshot_t *redo_stack;
+    unsigned redo_count;
 } globals_t;
 
 /* global settings */
@@ -81,6 +96,10 @@ const char *sm_get_version(void);
 double sm_get_scan_progress(void);
 void sm_set_stop_flag(bool stop_flag);
 bool sm_reset(void);
+bool sm_undo_scan(void);
+bool sm_redo_scan(void);
+void sm_history_record(void);
+void sm_history_clear(void);
 
 /* ptrace.c */
 bool sm_detach(pid_t target);

--- a/scanmem.h
+++ b/scanmem.h
@@ -63,6 +63,9 @@ typedef struct {
         unsigned short no_ptrace;
         unsigned short threads;    /* 0 means pick from online CPUs */
     } options;
+    /* set while a scan owns vars->matches. appended at the end of the struct
+       on purpose so existing member offsets do not move. */
+    volatile bool scan_in_progress;
 } globals_t;
 
 /* global settings */
@@ -77,6 +80,7 @@ unsigned long sm_get_num_matches(void);
 const char *sm_get_version(void);
 double sm_get_scan_progress(void);
 void sm_set_stop_flag(bool stop_flag);
+bool sm_reset(void);
 
 /* ptrace.c */
 bool sm_detach(pid_t target);

--- a/scanroutines.c
+++ b/scanroutines.c
@@ -198,16 +198,18 @@ DEFINE_FLOAT_ROUTINE_FOR_ALL_FLOAT_TYPES(DECREASED, <, old_value, 0, )
 /*---------------------------------*/
 /* for INCREASEDBY and DECREASEDBY */
 /*---------------------------------*/
+/* NOTE: the OP expression is parenthesised. == binds tighter than ^, so
+   without it the XOR routine below would compare (mem == old) ^ user. */
 #define DEFINE_INTEGER_OPERATIONBY_ROUTINE(DATAWIDTH, NAME, OP) \
     extern inline unsigned int scan_routine_INTEGER##DATAWIDTH##_##NAME SCAN_ROUTINE_ARGUMENTS \
     { \
         if (memlength < (DATAWIDTH)/8) return 0; \
         int ret = 0; \
         if ((GET_FLAG(old_value, s##DATAWIDTH##b)) && (GET_FLAG(user_value, s##DATAWIDTH##b)) && \
-            (get_s##DATAWIDTH##b(memory_ptr) == get_s##DATAWIDTH##b(old_value) OP get_s##DATAWIDTH##b(user_value))) \
+            (get_s##DATAWIDTH##b(memory_ptr) == (get_s##DATAWIDTH##b(old_value) OP get_s##DATAWIDTH##b(user_value)))) \
             { ret = (DATAWIDTH)/8; SET_FLAG(saveflags, s##DATAWIDTH##b); } \
         if ((GET_FLAG(old_value, u##DATAWIDTH##b)) && (GET_FLAG(user_value, u##DATAWIDTH##b)) && \
-            (get_u##DATAWIDTH##b(memory_ptr) == get_u##DATAWIDTH##b(old_value) OP get_u##DATAWIDTH##b(user_value))) \
+            (get_u##DATAWIDTH##b(memory_ptr) == (get_u##DATAWIDTH##b(old_value) OP get_u##DATAWIDTH##b(user_value)))) \
             { ret = (DATAWIDTH)/8; SET_FLAG(saveflags, u##DATAWIDTH##b); } \
         return ret; \
     }
@@ -227,7 +229,7 @@ DEFINE_INTEGER_INCREASEDBY_DECREASEDBY_ROUTINE(64)
         if (memlength < (DATAWIDTH)/8) return 0; \
         int ret = 0; \
         if ((GET_FLAG(old_value, f##DATAWIDTH##b)) && (GET_FLAG(user_value, f##DATAWIDTH##b)) && \
-            (get_f##DATAWIDTH##b(memory_ptr) == get_f##DATAWIDTH##b(old_value) OP get_f##DATAWIDTH##b(user_value))) \
+            (get_f##DATAWIDTH##b(memory_ptr) == (get_f##DATAWIDTH##b(old_value) OP get_f##DATAWIDTH##b(user_value)))) \
             { ret = (DATAWIDTH)/8; SET_FLAG(saveflags, f##DATAWIDTH##b); } \
         return ret; \
     }
@@ -238,6 +240,35 @@ DEFINE_INTEGER_INCREASEDBY_DECREASEDBY_ROUTINE(64)
 
 DEFINE_FLOAT_INCREASEDBY_DECREASEDBY_ROUTINE(32)
 DEFINE_FLOAT_INCREASEDBY_DECREASEDBY_ROUTINE(64)
+
+/*---------*/
+/* for XOR */
+/*---------*/
+
+/* XOR is its own inverse, so "the user's value equals mem ^ old" is the same
+   test as "mem equals old ^ user", which is the exact shape the OPERATIONBY
+   macro above already generates. Nothing new to write.
+
+   Integers only, on purpose. The original patch also did floats by casting
+   both sides to an integer first, which throws the fraction away and is
+   undefined as soon as the value does not fit the integer type, so it matched
+   on nonsense. XORing the bit pattern instead would be well defined but a
+   XORed float is almost never a valid float anyway. */
+DEFINE_INTEGER_OPERATIONBY_ROUTINE( 8, XORBY, ^)
+DEFINE_INTEGER_OPERATIONBY_ROUTINE(16, XORBY, ^)
+DEFINE_INTEGER_OPERATIONBY_ROUTINE(32, XORBY, ^)
+DEFINE_INTEGER_OPERATIONBY_ROUTINE(64, XORBY, ^)
+
+/* just the integer half of DEFINE_ANYTYPE_ROUTINE, there is no float one */
+extern inline unsigned int scan_routine_ANYINTEGER_XORBY SCAN_ROUTINE_ARGUMENTS
+{
+    int ret = scan_routine_INTEGER8_XORBY(memory_ptr, memlength, old_value, user_value, saveflags);
+    int tmp_ret;
+    if ((tmp_ret = scan_routine_INTEGER16_XORBY(memory_ptr, memlength, old_value, user_value, saveflags)) > ret) { ret = tmp_ret; }
+    if ((tmp_ret = scan_routine_INTEGER32_XORBY(memory_ptr, memlength, old_value, user_value, saveflags)) > ret) { ret = tmp_ret; }
+    if ((tmp_ret = scan_routine_INTEGER64_XORBY(memory_ptr, memlength, old_value, user_value, saveflags)) > ret) { ret = tmp_ret; }
+    return ret;
+}
 
 /*-----------*/
 /* for RANGE */
@@ -646,6 +677,14 @@ scan_routine_t sm_get_scanroutine(scan_data_type_t dt, scan_match_type_t mt, mat
     CHOOSE_ROUTINE_FOR_ALL_NUMBER_TYPES(MATCHDECREASED, DECREASED)
     CHOOSE_ROUTINE_FOR_ALL_NUMBER_TYPES(MATCHINCREASEDBY, INCREASEDBY)
     CHOOSE_ROUTINE_FOR_ALL_NUMBER_TYPES(MATCHDECREASEDBY, DECREASEDBY)
+
+    /* integer types only, see the XOR note above */
+    CHOOSE_ROUTINE(INTEGER8,   INTEGER8,   MATCHXORBY, XORBY)
+    CHOOSE_ROUTINE(INTEGER16,  INTEGER16,  MATCHXORBY, XORBY)
+    CHOOSE_ROUTINE(INTEGER32,  INTEGER32,  MATCHXORBY, XORBY)
+    CHOOSE_ROUTINE(INTEGER64,  INTEGER64,  MATCHXORBY, XORBY)
+    CHOOSE_ROUTINE(ANYINTEGER, ANYINTEGER, MATCHXORBY, XORBY)
+
     CHOOSE_ROUTINE_FOR_ALL_NUMBER_TYPES_AND_ENDIANS(MATCHRANGE, RANGE)
 
     CHOOSE_ROUTINE(BYTEARRAY, VLT, MATCHANY, ANY)
@@ -687,7 +726,8 @@ bool sm_choose_scanroutine(scan_data_type_t dt, scan_match_type_t mt, const user
         mt == MATCHLESSTHAN    ||
         mt == MATCHRANGE       ||
         mt == MATCHINCREASEDBY ||
-        mt == MATCHDECREASEDBY)
+        mt == MATCHDECREASEDBY ||
+        mt == MATCHXORBY)
     {
         match_flags possible_flags = possible_flags_for_scan_data_type[dt];
         if ((possible_flags & uflags) == flags_empty) {

--- a/scanroutines.h
+++ b/scanroutines.h
@@ -57,7 +57,8 @@ typedef enum {
     MATCHDECREASED,
     /* following: compare with both given value and old value */
     MATCHINCREASEDBY,
-    MATCHDECREASEDBY
+    MATCHDECREASEDBY,
+    MATCHXORBY               /* appended: keeps the existing values put */
 } scan_match_type_t;
 
 

--- a/targetmem.c
+++ b/targetmem.c
@@ -187,9 +187,20 @@ delete_in_address_range (matches_and_old_values_array *array,
                 (We can get away with assuming that the pointers will stay
                  valid, because as we never add more data to the array than
                  there was before, it will not reallocate.) */
-            writing_swath_index = add_element(&array,
-                                      writing_swath_index, address,
-                                      old_byte.old_value, old_byte.match_info);
+            {
+                matches_and_old_values_swath *new_swath;
+
+                new_swath = add_element(&array, writing_swath_index, address,
+                                        old_byte.old_value, old_byte.match_info);
+                /* cannot grow here in practice, this path only ever rewrites
+                   over what was already there, but do not write through NULL
+                   if that ever stops being true */
+                if (new_swath == NULL) {
+                    show_error("out of memory compacting the match list.\n");
+                    return NULL;
+                }
+                writing_swath_index = new_swath;
+            }
 
             /* actual matches are recorded */
             if (old_byte.match_info != flags_empty)

--- a/targetmem.h
+++ b/targetmem.h
@@ -161,8 +161,14 @@ allocate_enough_to_reach (matches_and_old_values_array *array,
             bytes_to_allocate = array->max_needed_bytes;
         }
 
-        if (!(array = realloc(array, bytes_to_allocate)))
+        /* into a temp: assigning realloc's result straight onto `array` loses
+           the only pointer to the existing allocation when it returns NULL,
+           so a failure here used to leak the whole match set as well as
+           handing the caller a NULL it did not check (#307). */
+        matches_and_old_values_array *grown = realloc(array, bytes_to_allocate);
+        if (grown == NULL)
             return NULL;
+        array = grown;
 
         array->bytes_allocated = bytes_to_allocate;
 
@@ -177,7 +183,10 @@ allocate_enough_to_reach (matches_and_old_values_array *array,
 }
 
 /* returns a pointer to the swath to which the element was added -
-   i.e. the last swath in the array after the operation */
+   i.e. the last swath in the array after the operation.
+   Returns NULL if the array could not be grown. The caller must stop: on
+   failure *array is left untouched and still valid, so it can be freed
+   normally, but nothing was recorded. */
 static inline matches_and_old_values_swath *
 add_element (matches_and_old_values_array **array,
              matches_and_old_values_swath *swath,
@@ -185,13 +194,18 @@ add_element (matches_and_old_values_array **array,
              uint8_t new_byte,
              match_flags new_flags)
 {
+    matches_and_old_values_array *grown;
+
     if (swath->number_of_bytes == 0) {
         assert(swath->first_byte_in_child == NULL);
 
         /* we have to overwrite this as a new swath */
-        *array = allocate_enough_to_reach(*array, (void *)swath +
+        grown = allocate_enough_to_reach(*array, (void *)swath +
             sizeof(matches_and_old_values_swath) +
             sizeof(old_value_and_match_info), &swath);
+        if (grown == NULL)
+            return NULL;
+        *array = grown;
 
         swath->first_byte_in_child = remote_address;
 
@@ -211,9 +225,12 @@ add_element (matches_and_old_values_array **array,
              * The equal case is decided for a new swath, so that
              * later we don't needlessly iterate through a bunch
              * of empty values */
-            *array = allocate_enough_to_reach(*array,
+            grown = allocate_enough_to_reach(*array,
                 local_address_beyond_last_element(swath) +
                 needed_size_for_a_new_swath, &swath);
+            if (grown == NULL)
+                return NULL;
+            *array = grown;
 
             swath = local_address_beyond_last_element(swath);
             swath->first_byte_in_child = remote_address;
@@ -222,9 +239,12 @@ add_element (matches_and_old_values_array **array,
         } else {
             /* It is more memory-efficient to write over the intervening
                space with null values */
-            *array = allocate_enough_to_reach(*array,
+            grown = allocate_enough_to_reach(*array,
                 local_address_beyond_last_element(swath) +
                 local_address_excess, &swath);
+            if (grown == NULL)
+                return NULL;
+            *array = grown;
 
             switch (local_index_excess) {
             case 1:

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -4,4 +4,4 @@ check_PROGRAMS = memfake
 memfake_SOURCES = memfake.c
 memfake_CFLAGS = -std=gnu99 -Wall
 
-EXTRA_DIST = lib.sh
+EXTRA_DIST = lib.sh $(TESTS)

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,4 @@
-TESTS = sm_test.sh scan_tests.sh cmd_tests.sh
+TESTS = sm_test.sh scan_tests.sh cmd_tests.sh align_tests.sh
 check_PROGRAMS = memfake
 
 memfake_SOURCES = memfake.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,4 @@
-TESTS = sm_test.sh scan_tests.sh
+TESTS = sm_test.sh scan_tests.sh cmd_tests.sh
 check_PROGRAMS = memfake
 
 memfake_SOURCES = memfake.c

--- a/test/align_tests.sh
+++ b/test/align_tests.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# `option alignment N` makes the scan only look at addresses that are a
+# multiple of N. The point is speed, but the thing worth asserting is that it
+# finds exactly the values on the boundary and none of the ones off it, and
+# that a match still narrows afterwards. The trailing bytes of a wide match
+# still have to be recorded even though they are never tested, otherwise the
+# old value cannot be rebuilt and the next scan drops the match.
+
+set -u
+cd "$(dirname "$0")"
+. ./lib.sh
+
+preflight
+
+VAL=305419896            # 0x12345678, four distinct bytes
+COUNT=8
+
+# planted on a 4 byte boundary
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+
+for a in 1 2 4; do
+    n=$(nth "$(run_scan "option scan_data_type int32\noption alignment $a\n$VAL\nexit")" 1)
+    assert_ge "$n" "$COUNT" "aligned plant is found with alignment $a"
+done
+
+# narrowing has to survive, which it only does if the bytes behind each match
+# were recorded while the scan skipped over them
+out=$(run_scan "option scan_data_type int32\noption alignment 4\n$VAL\n$(mutate_cmd)\n$((VAL + 1))\nexit")
+assert_eq "$(nth "$out" 2)" "$COUNT" "narrow after an aligned scan is exactly $COUNT"
+
+stop_memfake
+
+# same value, now one byte off the boundary every time
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4 --skew 1
+
+n1=$(nth "$(run_scan "option scan_data_type int32\noption alignment 1\n$VAL\nexit")" 1)
+assert_ge "$n1" "$COUNT" "skewed plant is found when every address is looked at"
+
+n4=$(nth "$(run_scan "option scan_data_type int32\noption alignment 4\n$VAL\nexit")" 1)
+if [ "${n4:-0}" -lt "$COUNT" ]; then
+    echo "ok: alignment 4 skips the skewed plant ($n4 left, was $n1)"
+    checks=$((checks + 1))
+else
+    echo "FAIL: alignment 4 still found $n4, it should miss the skewed plant"
+    checks=$((checks + 1)); fails=$((fails + 1))
+fi
+
+stop_memfake
+
+# bad values are refused rather than quietly accepted
+start_memfake --plant "$VAL" --count 1 --width 4 --mb 1
+for bad in 0 3 16 -4 x; do
+    out=$(printf 'option alignment %s\nexit\n' "$bad" \
+          | $sudo_prefix timeout 60 $SCANMEM -p "$mf_pid" 2>&1)
+    case "$out" in
+        *"alignment must be"*) echo "ok: alignment $bad refused"; checks=$((checks + 1)) ;;
+        *) echo "FAIL: alignment $bad was not refused"; checks=$((checks + 1)); fails=$((fails + 1)) ;;
+    esac
+done
+stop_memfake
+
+summary

--- a/test/cmd_tests.sh
+++ b/test/cmd_tests.sh
@@ -156,6 +156,66 @@ echo "$out" | grep -q "too many values" \
     && assert_eq yes yes "+ still rejects two values" \
     || assert_eq no yes "+ still rejects two values"
 
+# ---- scan undo / redo (#389) ----
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+
+# scan, narrow, then step back and forward again
+out=$(run_scan "option undo_limit 5\noption scan_data_type int32\n$VAL\n$(mutate_cmd)\n$NEXT\nundo\nredo\nexit")
+c1=$(nth "$out" 1); c2=$(nth "$out" 2)
+assert_eq "$(nth "$out" 3)" "$c1" "undo restores the pre-narrow match count"
+assert_eq "$(nth "$out" 4)" "$c2" "redo returns to the narrowed match count"
+[ "${c2:-0}" -lt "${c1:-0}" ] \
+    && assert_eq yes yes "control: the narrow actually reduced the set" \
+    || assert_eq no yes "control: the narrow actually reduced the set"
+
+# undoing past the first scan lands on an empty set, not an error
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+out=$(run_scan "option undo_limit 5\noption scan_data_type int32\n$VAL\nundo\nexit")
+assert_eq "$(nth "$out" 2)" "0" "undo past the first scan gives an empty set"
+
+# a fresh scan must throw away the redo chain
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+out=$(run_raw "option undo_limit 5\noption scan_data_type int32\n$VAL\n$(mutate_cmd)\n$NEXT\nundo\n$NEXT\nredo\nexit")
+echo "$out" | grep -q "nothing to redo" \
+    && assert_eq yes yes "a new scan discards the redo chain" \
+    || assert_eq no yes "a new scan discards the redo chain"
+
+# the limit is honoured: with 1 remembered scan only one step back works
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+out=$(run_raw "option undo_limit 1\noption scan_data_type int32\n$VAL\n$(mutate_cmd)\n$NEXT\nundo\nundo\nexit")
+echo "$out" | grep -q "nothing to undo" \
+    && assert_eq yes yes "undo_limit caps how far back you can go" \
+    || assert_eq no yes "undo_limit caps how far back you can go"
+
+# off by default
+out=$(run_raw "option scan_data_type int32\n$VAL\nundo\nexit")
+echo "$out" | grep -q "undo is disabled" \
+    && assert_eq yes yes "undo is off unless undo_limit is set" \
+    || assert_eq no yes "undo is off unless undo_limit is set"
+
+# reset must drop the history, the snapshots no longer mean anything
+out=$(run_raw "option undo_limit 5\noption scan_data_type int32\n$VAL\nreset\nundo\nexit")
+echo "$out" | grep -q "nothing to undo" \
+    && assert_eq yes yes "reset clears the undo history" \
+    || assert_eq no yes "reset clears the undo history"
+
+out=$(run_raw "option undo_limit 5\noption scan_data_type int32\n$VAL\nreset keep-regions\nundo\nexit")
+echo "$out" | grep -q "nothing to undo" \
+    && assert_eq yes yes "reset keep-regions clears the undo history" \
+    || assert_eq no yes "reset keep-regions clears the undo history"
+
+# a negative limit must not wrap round to 65535
+for bad in -1 abc 70000 "12x"; do
+    out=$(run_raw "option undo_limit $bad\nexit")
+    echo "$out" | grep -q "undo_limit must be between" \
+        && assert_eq yes yes "option undo_limit rejects $bad" \
+        || assert_eq no yes "option undo_limit rejects $bad"
+done
+
 # ---- sm_reset is a public API symbol (#312) ----
 # the whole point of the PR is that a front end can call this without going
 # through the command parser, so check it actually made it out of the .so

--- a/test/cmd_tests.sh
+++ b/test/cmd_tests.sh
@@ -216,6 +216,46 @@ for bad in -1 abc 70000 "12x"; do
         || assert_eq no yes "option undo_limit rejects $bad"
 done
 
+# ---- memdiff (#403) ----
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+
+md_addr=$(printf 'option scan_data_type int32\n%s\nlist\nexit\n' "$VAL" \
+    | $sudo_prefix timeout 120 $SCANMEM -p "$mf_pid" 2>/dev/null \
+    | sed -n 's/^\[ *[0-9]*\][ ,]*\([0-9a-f]*\),.*/\1/p' | head -1)
+assert_ge "${#md_addr}" 4 "found an address to watch"
+
+# memdiff runs until interrupted, so cap it
+md_run() { printf '%b\n' "$1" | $sudo_prefix timeout "${2:-4}" $SCANMEM -p "$mf_pid" 2>&1; }
+
+# the table must start at the requested address, not one byte in. VAL is
+# 0x12d687 so the first four bytes little endian are 87 d6 12 00.
+out=$(md_run "memdiff $md_addr 16" 3 | grep -iE "^0x$md_addr: " | head -1)
+echo "$out" | grep -qiE ": 87 d6 12 00 " \
+    && assert_eq yes yes "table starts at the first byte of the region" \
+    || assert_eq no yes "table starts at the first byte of the region"
+
+# a short trailing row must be padded so the ascii column still lines up
+out=$(md_run "memdiff $md_addr 20" 3 | grep -icE "^0x[0-9a-f]+: " || true)
+assert_ge "$out" 2 "a length that is not a multiple of 16 emits a short row"
+
+# and it must actually notice a change
+( sleep 2; kill -USR1 "$mf_pid" 2>/dev/null ) &
+out=$(md_run "memdiff $md_addr 32 list" 5 | grep -c "=>" || true)
+assert_ge "$out" 1 "list mode reports a byte that changed"
+
+# no colour when the output is not a terminal, the gui parses this
+out=$(md_run "memdiff $md_addr 16" 3 | grep -c "$(printf '\033')" || true)
+assert_eq "$out" "0" "no escape codes when stdout is not a tty"
+
+for bad in "memdiff" "memdiff $md_addr" "memdiff $md_addr 0" \
+           "memdiff $md_addr 99999999999" "memdiff $md_addr 16 bogus" "memdiff zz 16"; do
+    out=$(run_raw "$bad\nexit")
+    echo "$out" | grep -q "error:" \
+        && assert_eq yes yes "rejected: $bad" \
+        || assert_eq no yes "rejected: $bad"
+done
+
 # ---- sm_reset is a public API symbol (#312) ----
 # the whole point of the PR is that a front end can call this without going
 # through the command parser, so check it actually made it out of the .so

--- a/test/cmd_tests.sh
+++ b/test/cmd_tests.sh
@@ -101,5 +101,17 @@ echo "$out" | grep -q "no target set" \
     && assert_eq yes yes "read with no target explains itself" \
     || assert_eq no yes "read with no target explains itself"
 
+# ---- sm_reset is a public API symbol (#312) ----
+# the whole point of the PR is that a front end can call this without going
+# through the command parser, so check it actually made it out of the .so
+lib=../.libs/libscanmem.so
+if [ -f "$lib" ] && command -v nm >/dev/null 2>&1; then
+    nm -D --defined-only "$lib" 2>/dev/null | grep -q " T sm_reset$" \
+        && assert_eq yes yes "sm_reset is exported from libscanmem" \
+        || assert_eq no yes "sm_reset is exported from libscanmem"
+else
+    echo "skip: no shared lib or nm, not checking sm_reset export"
+fi
+
 stop_memfake
 summary

--- a/test/cmd_tests.sh
+++ b/test/cmd_tests.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Tests for the CLI commands, as opposed to scan correctness which lives in
+# scan_tests.sh. Added while working the PR backlog: `reset keep-regions`
+# (#145) and `read` (#346) both went in without any test at all.
+
+set -u
+cd "$(dirname "$0")"
+. ./lib.sh
+
+preflight
+
+VAL=1234567
+COUNT=64
+
+# raw run, stderr included, so we can assert on error text
+run_raw() {
+    printf '%b\n' "$1" | $sudo_prefix timeout 120 $SCANMEM -p "$mf_pid" 2>&1
+}
+
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+
+# ---- reset keep-regions (#145) ----
+
+# control: without a reset the matches are still listed
+out=$(run_list "option scan_data_type int32\n$VAL\nlist\nexit")
+n=$(echo "$out" | grep -c . || true)
+assert_ge "$n" 1 "control: matches are listed when nothing reset them"
+
+# keep-regions still forgets the matches
+out=$(run_list "option scan_data_type int32\n$VAL\nreset keep-regions\nlist\nexit")
+n=$(echo "$out" | grep -c . || true)
+assert_eq "$n" 0 "reset keep-regions forgets the matches"
+
+# and the region list survives, so a second scan still finds the value.
+# if regions had been dropped without a reread this would come back empty.
+out=$(run_scan "option scan_data_type int32\n$VAL\nreset keep-regions\n$VAL\nexit")
+first=$(nth "$out" 1)
+second=$(nth "$out" 2)
+assert_ge "$first" "$COUNT" "first scan finds the planted values"
+assert_eq "$second" "$first" "scan after reset keep-regions finds the same count"
+
+# plain reset rereads maps and still works
+out=$(run_scan "option scan_data_type int32\n$VAL\nreset\n$VAL\nexit")
+assert_eq "$(nth "$out" 2)" "$(nth "$out" 1)" "scan after a plain reset finds the same count"
+
+# a typo must be refused, not silently treated as a plain reset
+out=$(run_raw "reset keepregions\nexit")
+echo "$out" | grep -q "unrecognised argument" \
+    && assert_eq yes yes "reset rejects an unknown argument" \
+    || assert_eq no yes "reset rejects an unknown argument"
+
+# refusing it must also leave the matches alone
+out=$(run_list "option scan_data_type int32\n$VAL\nreset keepregions\nlist\nexit")
+n=$(echo "$out" | grep -c . || true)
+assert_ge "$n" 1 "a refused reset does not drop the matches"
+
+out=$(run_raw "reset a b c\nexit")
+echo "$out" | grep -q "bad arguments" \
+    && assert_eq yes yes "reset rejects too many arguments" \
+    || assert_eq no yes "reset rejects too many arguments"
+
+stop_memfake
+summary

--- a/test/cmd_tests.sh
+++ b/test/cmd_tests.sh
@@ -59,5 +59,47 @@ echo "$out" | grep -q "bad arguments" \
     && assert_eq yes yes "reset rejects too many arguments" \
     || assert_eq no yes "reset rejects too many arguments"
 
+# ---- read (#346) ----
+
+# grab a real address out of the match list to read from
+first_addr=$(printf 'option scan_data_type int32\n%s\nlist\nexit\n' "$VAL" \
+    | $sudo_prefix timeout 120 $SCANMEM -p "$mf_pid" 2>/dev/null \
+    | sed -n 's/^\[ *[0-9]*\][ ,]*\([0-9a-f]*\),.*/\1/p' | head -1)
+assert_ge "${#first_addr}" 4 "found an address to read from"
+
+out=$(run_raw "read int32 $first_addr\nexit" | grep -E '^-?[0-9]+$' | tail -1)
+assert_eq "$out" "$VAL" "read int32 returns the planted value"
+
+# round trip against write, which is the whole point of having both
+out=$(run_raw "write int32 $first_addr 999\nread int32 $first_addr\nexit" | grep -E '^-?[0-9]+$' | tail -1)
+assert_eq "$out" "999" "read sees what write just wrote"
+
+# a wider read at the same spot must not fault or truncate to the 32 bit value
+out=$(run_raw "read int64 $first_addr\nexit" | grep -E '^-?[0-9]+$' | tail -1)
+assert_ge "${#out}" 1 "read int64 at the same address produces a value"
+
+# error paths. the original patch returned an uninitialised bool on success,
+# so these also pin down that a bad command reports failure rather than luck.
+for bad in "read" "read int32" "read bogus 1000" "read int32 zzz" "read int32 1000 extra"; do
+    out=$(run_raw "$bad\nexit")
+    echo "$out" | grep -q "error:" \
+        && assert_eq yes yes "rejected: $bad" \
+        || assert_eq no yes "rejected: $bad"
+done
+
+# write swaps bytes when reverse endianness is on, so read has to swap back
+# or the pair stops round tripping. checks the claim in the code comment.
+for e in 0 1 2; do
+    out=$(run_raw "option endianness $e\nwrite int32 $first_addr 305419896\nread int32 $first_addr\nexit" \
+          | grep -E '^-?[0-9]+$' | tail -1)
+    assert_eq "$out" "305419896" "write then read round trips at endianness $e"
+done
+
+# reading with no process attached must say so, not just fail to read
+out=$(printf 'read int32 1000\nexit\n' | $sudo_prefix timeout 120 $SCANMEM 2>&1)
+echo "$out" | grep -q "no target set" \
+    && assert_eq yes yes "read with no target explains itself" \
+    || assert_eq no yes "read with no target explains itself"
+
 stop_memfake
 summary

--- a/test/cmd_tests.sh
+++ b/test/cmd_tests.sh
@@ -101,6 +101,30 @@ echo "$out" | grep -q "no target set" \
     && assert_eq yes yes "read with no target explains itself" \
     || assert_eq no yes "read with no target explains itself"
 
+# ---- unsigned type names (#359) ----
+# GameConqueror's type dropdown offers uint8..uint64. the parser only knew the
+# signed names, so `write uint8 ...` was refused and the GUI's write silently
+# did nothing, which is what #359 reports as "stops accepting new values".
+for t in uint8 uint16 uint32 uint64 u8 u16 u32 u64; do
+    out=$(run_raw "write $t $first_addr 1\nexit")
+    echo "$out" | grep -q "bad data_type" \
+        && assert_eq no yes "write accepts $t" \
+        || assert_eq yes yes "write accepts $t"
+done
+
+# values that only fit unsigned must survive a round trip
+out=$(run_raw "write uint8 $first_addr 200\nread uint8 $first_addr\nexit" | grep -E '^[0-9]+$' | tail -1)
+assert_eq "$out" "200" "uint8 200 round trips"
+# same byte read signed is the negative counterpart, so only the format changed
+out=$(run_raw "read int8 $first_addr\nexit" | grep -E '^-?[0-9]+$' | tail -1)
+assert_eq "$out" "-56" "the same byte read as int8 is -56"
+
+out=$(run_raw "write uint32 $first_addr 4000000000\nread uint32 $first_addr\nexit" | grep -E '^[0-9]+$' | tail -1)
+assert_eq "$out" "4000000000" "uint32 above INT32_MAX round trips"
+
+out=$(run_raw "write uint64 $first_addr 18446744073709551615\nread uint64 $first_addr\nexit" | grep -E '^[0-9]+$' | tail -1)
+assert_eq "$out" "18446744073709551615" "uint64 max round trips"
+
 # ---- xor between scan rounds (#424) ----
 # earlier tests wrote over one of the planted slots, so start clean
 stop_memfake

--- a/test/cmd_tests.sh
+++ b/test/cmd_tests.sh
@@ -101,6 +101,61 @@ echo "$out" | grep -q "no target set" \
     && assert_eq yes yes "read with no target explains itself" \
     || assert_eq no yes "read with no target explains itself"
 
+# ---- xor between scan rounds (#424) ----
+# earlier tests wrote over one of the planted slots, so start clean
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+
+NEXT=$((VAL + 1))
+DELTA=$((VAL ^ NEXT))
+
+# baseline: the ordinary narrow, so we know what the xor should reproduce
+out=$(run_scan "option scan_data_type int32\n$VAL\n$(mutate_cmd)\n$NEXT\nexit")
+expect=$(nth "$out" 2)
+assert_ge "$expect" "$COUNT" "control: plain narrow finds the planted values"
+
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+out=$(run_scan "option scan_data_type int32\n$VAL\n$(mutate_cmd)\n^ $DELTA\nexit")
+assert_eq "$(nth "$out" 2)" "$expect" "one arg xor narrows to the same set"
+
+# two arg form: the key cancels, so ^ n m must equal ^ (n^m)
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+out=$(run_scan "option scan_data_type int32\n$VAL\n$(mutate_cmd)\n^ $VAL $NEXT\nexit")
+assert_eq "$(nth "$out" 2)" "$expect" "two arg xor narrows to the same set"
+
+# a wrong delta must not match the planted slots
+stop_memfake
+start_memfake --plant "$VAL" --count "$COUNT" --width 4 --mb 4
+out=$(run_scan "option scan_data_type int32\n$VAL\n$(mutate_cmd)\n^ $((DELTA ^ 0xff))\nexit")
+second=$(nth "$out" 2)
+[ "${second:-0}" -lt "$expect" ] \
+    && assert_eq yes yes "a wrong xor delta does not match" \
+    || assert_eq no yes "a wrong xor delta does not match"
+
+# xor cannot be a first scan, there is no old value to compare against
+out=$(run_raw "^ 5\nexit")
+echo "$out" | grep -q "without matches" \
+    && assert_eq yes yes "xor is refused as a first scan" \
+    || assert_eq no yes "xor is refused as a first scan"
+
+out=$(run_raw "option scan_data_type int32\n$VAL\n^\nexit")
+echo "$out" | grep -q "one or two values" \
+    && assert_eq yes yes "xor with no value is refused" \
+    || assert_eq no yes "xor with no value is refused"
+
+out=$(run_raw "option scan_data_type int32\n$VAL\n^ 1 2 3\nexit")
+echo "$out" | grep -q "too many values" \
+    && assert_eq yes yes "xor with three values is refused" \
+    || assert_eq no yes "xor with three values is refused"
+
+# the other operators must still reject a second value
+out=$(run_raw "option scan_data_type int32\n$VAL\n+ 1 2\nexit")
+echo "$out" | grep -q "too many values" \
+    && assert_eq yes yes "+ still rejects two values" \
+    || assert_eq no yes "+ still rejects two values"
+
 # ---- sm_reset is a public API symbol (#312) ----
 # the whole point of the PR is that a front end can call this without going
 # through the command parser, so check it actually made it out of the .so

--- a/test/memfake.c
+++ b/test/memfake.c
@@ -196,10 +196,13 @@ int main(int argc, char **argv)
        the signal should come back with exactly plant_count. the process's own
        copies of the value (locals, spilled registers) keep the old value and
        drop out of the match set, which is what makes the count exact. */
+    unsigned mutate_n = 0;
     for (;;) {
         pause();
         if (!got_mutate) continue;
         got_mutate = 0;
+        mutate_n++; /* each signal advances the value: plant+1, plant+2, ... so
+                       a test can narrow twice and shake off a 1-byte phantom */
 
         if (mode == MODE_BYTES) {
             size_t stride = total_bytes / (plant_count ? plant_count : 1);
@@ -211,10 +214,10 @@ int main(int argc, char **argv)
         } else {
             uint64_t pattern2;
             if (mode == MODE_FLOAT) {
-                if (width == 4) { float f = (float)plant_f + 1.0f; pattern2 = 0; memcpy(&pattern2, &f, 4); }
-                else { double d = plant_f + 1.0; memcpy(&pattern2, &d, 8); }
+                if (width == 4) { float f = (float)plant_f + (float)mutate_n; pattern2 = 0; memcpy(&pattern2, &f, 4); }
+                else { double d = plant_f + (double)mutate_n; memcpy(&pattern2, &d, 8); }
             } else {
-                pattern2 = plant + 1;
+                pattern2 = plant + mutate_n;
             }
             size_t slots = total_bytes / width;
             size_t stride = slots / (plant_count ? plant_count : 1);

--- a/test/memfake.c
+++ b/test/memfake.c
@@ -63,6 +63,15 @@ static uint64_t pick_filler(uint64_t planted, unsigned width)
     return f;
 }
 
+/* Nothing in this process ever reads the planted buffer back, it exists to be
+   read over ptrace by the scanner. clang at -O2 works that out and drops the
+   stores, and the whole suite then fails on a target that never held the
+   values. Force the writes to stay. */
+static void keep(void *p)
+{
+    __asm__ __volatile__("" :: "r"(p) : "memory");
+}
+
 static void fill(void *base, size_t bytes, uint64_t pattern, unsigned width)
 {
     unsigned char *p = base;
@@ -144,6 +153,7 @@ int main(int argc, char **argv)
             }
         }
 
+        keep(array);
         printf("%d\n", (int)getpid());
         fflush(stdout);
         signal_ready(ready_path);
@@ -186,6 +196,8 @@ int main(int argc, char **argv)
             memcpy(buf + (i * stride) * width, &pattern, width);
     }
 
+    keep(buf);
+
     signal(SIGUSR1, on_mutate);
 
     printf("%d\n", (int)getpid());
@@ -224,6 +236,8 @@ int main(int argc, char **argv)
             for (size_t i = 0; i < plant_count; i++)
                 memcpy(buf + (i * stride) * width, &pattern2, width);
         }
+
+        keep(buf);
 
         /* tell the harness the rewrite finished. without this the next scan
            can attach (which SIGSTOPs us) while we are still partway through,

--- a/test/memfake.c
+++ b/test/memfake.c
@@ -41,7 +41,7 @@ static void usage(const char *argv0)
 {
     fprintf(stderr,
         "usage: %s [MB] [randomness]\n"
-        "       %s --plant VALUE --count N [--width 1|2|4|8] [--mb N]\n"
+        "       %s --plant VALUE --count N [--width 1|2|4|8] [--mb N] [--skew N]\n"
         "       %s --plant-float VALUE --count N [--width 4|8] [--mb N]\n"
         "       %s --plant-bytes HEXSTRING --count N [--mb N]\n"
         "\n"
@@ -98,6 +98,7 @@ int main(int argc, char **argv)
     size_t plant_bytes_len = 0;
     size_t plant_count = 0;
     unsigned width = 4;
+    size_t skew = 0;                /* shift every plant off its natural boundary */
     enum { MODE_LEGACY, MODE_INT, MODE_FLOAT, MODE_BYTES } mode = MODE_LEGACY;
     const char *ready_path = NULL;
     const char *done_path = NULL;
@@ -123,6 +124,7 @@ int main(int argc, char **argv)
             else if (!strcmp(a, "--count") && next) { plant_count = strtoul(next, NULL, 10); i++; }
             else if (!strcmp(a, "--width") && next) { width = strtoul(next, NULL, 10); i++; }
             else if (!strcmp(a, "--mb") && next) { MB_to_allocate = strtoul(next, NULL, 10); i++; }
+            else if (!strcmp(a, "--skew") && next) { skew = strtoul(next, NULL, 10); i++; }
             else if (!strcmp(a, "--ready-file") && next) { ready_path = next; i++; }
             else if (!strcmp(a, "--done-file") && next) { done_path = next; i++; }
             else { usage(argv[0]); return 1; }
@@ -132,6 +134,7 @@ int main(int argc, char **argv)
             if (mode == MODE_FLOAT && width != 4 && width != 8) { usage(argv[0]); return 1; }
         }
         if (!plant_count) { usage(argv[0]); return 1; }
+        if (skew >= 8) { fprintf(stderr, "memfake: --skew must be under 8\n"); return 1; }
     } else {
         if (argc >= 2) MB_to_allocate = strtoul(argv[1], NULL, 10);
         if (argc >= 3) add_randomness = strtoul(argv[2], NULL, 10);
@@ -172,9 +175,9 @@ int main(int argc, char **argv)
         if (plant_bytes_len && plant_bytes[0] == 0x5a) memset(buf, 0x17, total_bytes);
 
         size_t stride = total_bytes / (plant_count ? plant_count : 1);
-        if (stride < plant_bytes_len) { fprintf(stderr, "memfake: buffer too small for that count\n"); return 1; }
+        if (stride < plant_bytes_len + skew) { fprintf(stderr, "memfake: buffer too small for that count\n"); return 1; }
         for (size_t i = 0; i < plant_count; i++)
-            memcpy(buf + i * stride, plant_bytes, plant_bytes_len);
+            memcpy(buf + i * stride + skew, plant_bytes, plant_bytes_len);
     } else {
         uint64_t pattern;
         if (mode == MODE_FLOAT) {
@@ -189,11 +192,11 @@ int main(int argc, char **argv)
 
         /* space the planted values out so they land in different pages, that
            way a batched read has to actually gather from several places */
-        size_t slots = total_bytes / width;
+        size_t slots = (total_bytes - skew) / width;
         size_t stride = slots / (plant_count ? plant_count : 1);
         if (!stride) { fprintf(stderr, "memfake: buffer too small for that count\n"); return 1; }
         for (size_t i = 0; i < plant_count; i++)
-            memcpy(buf + (i * stride) * width, &pattern, width);
+            memcpy(buf + (i * stride) * width + skew, &pattern, width);
     }
 
     keep(buf);
@@ -222,7 +225,7 @@ int main(int argc, char **argv)
             memcpy(flipped, plant_bytes, plant_bytes_len);
             flipped[0] = (unsigned char)(flipped[0] ^ 0xff);
             for (size_t i = 0; i < plant_count; i++)
-                memcpy(buf + i * stride, flipped, plant_bytes_len);
+                memcpy(buf + i * stride + skew, flipped, plant_bytes_len);
         } else {
             uint64_t pattern2;
             if (mode == MODE_FLOAT) {
@@ -234,7 +237,7 @@ int main(int argc, char **argv)
             size_t slots = total_bytes / width;
             size_t stride = slots / (plant_count ? plant_count : 1);
             for (size_t i = 0; i < plant_count; i++)
-                memcpy(buf + (i * stride) * width, &pattern2, width);
+                memcpy(buf + (i * stride) * width + skew, &pattern2, width);
         }
 
         keep(buf);

--- a/test/scan_tests.sh
+++ b/test/scan_tests.sh
@@ -19,14 +19,25 @@ preflight
 run_int_case() {
     local type=$1 width=$2 val=$3 count=$4
     start_memfake --plant "$val" --count "$count" --width "$width" --mb 4
-    local next=$((val + 1))
-    local out
-    out=$(run_scan "option scan_data_type $type\n$val\n$(mutate_cmd)\n$next\nexit")
-    local first last
-    first=$(nth "$out" 1)
-    last=$(nth "$out" 2)
-    assert_ge "$first" "$count" "$type: initial scan finds at least the $count planted"
-    assert_eq "$last" "$count" "$type: narrow after mutation is exactly $count"
+    local n1=$((val + 1)) n2=$((val + 2))
+    local out first
+    if [ "$width" -eq 1 ]; then
+        # a 1-byte value collides with incidental bytes all over the process. an
+        # incidental that happens to drift val -> val+1 between the two scans
+        # survives a single narrow as a phantom (this is a rare CI flake). narrow
+        # twice: the same address would also have to drift val+1 -> val+2 in the
+        # next window, which does not happen, so the second narrow lands on
+        # exactly the planted set.
+        out=$(run_scan "option scan_data_type $type\n$val\n$(mutate_cmd)\n$n1\n$(mutate_cmd)\n$n2\nexit")
+        first=$(nth "$out" 1)
+        assert_ge "$first" "$count" "$type: initial scan finds at least the $count planted"
+        assert_eq "$(nth "$out" 3)" "$count" "$type: narrow after mutation is exactly $count"
+    else
+        out=$(run_scan "option scan_data_type $type\n$val\n$(mutate_cmd)\n$n1\nexit")
+        first=$(nth "$out" 1)
+        assert_ge "$first" "$count" "$type: initial scan finds at least the $count planted"
+        assert_eq "$(nth "$out" 2)" "$count" "$type: narrow after mutation is exactly $count"
+    fi
     stop_memfake
 }
 

--- a/value.c
+++ b/value.c
@@ -112,6 +112,28 @@ void uservalue2value(value_t *dst, const uservalue_t *src)
     else assert(false);
 }
 
+/* Folds src into dst, per type, so a two operand XOR search can be handed to
+   the scan as a single value. dst->flags picks which types take part. */
+void xor_uservalue(uservalue_t *dst, const uservalue_t *src)
+{
+    /* Only types both operands can actually represent survive. `^ 5 300`
+       has no meaningful 8 bit answer because 300 never parsed as one. */
+    dst->flags &= src->flags;
+
+    /* uservalue_t is a struct with one field per type, not a union, so every
+       width is folded on its own. The original patch zeroed uint64_value up
+       front and then read it straight back, so the u64 result came out as
+       plain src instead of dst ^ src. */
+    if (dst->flags & flag_u64b) set_u64b(dst, get_u64b(dst) ^ get_u64b(src));
+    if (dst->flags & flag_s64b) set_s64b(dst, get_s64b(dst) ^ get_s64b(src));
+    if (dst->flags & flag_u32b) set_u32b(dst, get_u32b(dst) ^ get_u32b(src));
+    if (dst->flags & flag_s32b) set_s32b(dst, get_s32b(dst) ^ get_s32b(src));
+    if (dst->flags & flag_u16b) set_u16b(dst, get_u16b(dst) ^ get_u16b(src));
+    if (dst->flags & flag_s16b) set_s16b(dst, get_s16b(dst) ^ get_s16b(src));
+    if (dst->flags & flag_u8b)  set_u8b (dst, get_u8b(dst)  ^ get_u8b(src));
+    if (dst->flags & flag_s8b)  set_s8b (dst, get_s8b(dst)  ^ get_s8b(src));
+}
+
 /* parse bytearray, it will allocate the arrays itself, then needs to be free'd by `free_uservalue()` */
 bool parse_uservalue_bytearray(char *const *argv, unsigned argc, uservalue_t *val)
 {

--- a/value.h
+++ b/value.h
@@ -156,6 +156,7 @@ bool parse_uservalue_float(const char *nptr, uservalue_t * val);
 void free_uservalue(uservalue_t *uval);
 void valcpy(value_t * dst, const value_t * src);
 void uservalue2value(value_t * dst, const uservalue_t * src); /* dst.flags must be set beforehand */
+void xor_uservalue(uservalue_t * dst, const uservalue_t * src);
 
 #define get_s8b(val) ((val)->int8_value)
 #define get_u8b(val) ((val)->uint8_value)


### PR DESCRIPTION
Branched off #461, so the perf commits are in here too. Take that one first, or take this and close it, whichever suits.

PRs worked through, with the defects found in them fixed on top: #346 read command (its `ret` was uninitialised, returning stack garbage), #389 undo and redo (NULL into TAILQ_REMOVE after a reset), #403 region monitoring (off by one shifting every byte), #424 xor (wrong result for anything but u64, and float truncation UB), #145 reset keep-regions, #312 sm_reset, #348 stack offsets, #381 Wclobbered. #376 and #423 are closed by the undo and xor work.

Issues fixed: #307 OOM segfault, #359 unsigned type names, #398 gi version warning, #298 polkit namespace, #434 blank ps line, #456 lock flags, #452 maps VLA, #435 and #450 clipboard without a display, #438 python3 shebang, #401 string field length, #427, #413 and #430 launcher, #441 android cross compile, #282 the test suite.

Also C11 and hardening flags with the three bugs those turned up, and CI on 24.04 with both compilers plus sanitizers.

The clang miscompile I claimed earlier was not real. It was test/memfake.c: nothing in that process reads the planted buffer back, the scanner reads it over ptrace, so clang drops the stores as dead at -O2 and configure's CFLAGS reach the fixture too. Fixed with a barrier, clang is a blocking job again, and I have taken the claim out of the docs and the man page.

Every feature has a check that fails when the feature is deliberately broken, so the tests are not passing vacuously. valgrind clean over the undo, memdiff and stack paths. The OOM fix was verified under ulimit, the unchecked build exits 139.

The android part is checked against stub toolchain binaries only, not a real NDK.
