### PR TITLE
handlers: add `range` to crop the scan to an address window

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -668,6 +668,101 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc)
     return true;
 }
 
+/* drop matches that fall in [from, to), if there are any to drop */
+static void forget_matches(globals_t *vars, unsigned long from, unsigned long to)
+{
+    if (vars->num_matches == 0 || from >= to)
+        return;
+
+    vars->matches = delete_in_address_range(vars->matches, &vars->num_matches,
+                                            (void *)from, (void *)to);
+    if (vars->matches == NULL)
+        show_error("memory allocation error while deleting matches\n");
+}
+
+bool handler__range(globals_t * vars, char **argv, unsigned argc)
+{
+    unsigned long lo, hi;
+    char *endptr;
+    element_t *np, *pp = NULL;
+    size_t kept = 0, cropped = 0, dropped = 0;
+
+    if (argc != 3) {
+        show_error("expected two addresses, see `help range`.\n");
+        return false;
+    }
+
+    if (vars->target == 0) {
+        show_error("no target specified, see `help pid`\n");
+        return false;
+    }
+
+    if (vars->regions->size == 0) {
+        show_error("no regions are known.\n");
+        return false;
+    }
+
+    errno = 0;
+    lo = strtoul(argv[1], &endptr, 16);
+    if (errno != 0 || *endptr != '\0') {
+        show_error("bad start address, see `help range`.\n");
+        return false;
+    }
+
+    errno = 0;
+    hi = strtoul(argv[2], &endptr, 16);
+    if (errno != 0 || *endptr != '\0') {
+        show_error("bad end address, see `help range`.\n");
+        return false;
+    }
+
+    if (lo >= hi) {
+        show_error("the end address has to be above the start one.\n");
+        return false;
+    }
+
+    np = vars->regions->head;
+    while (np) {
+        region_t *r = np->data;
+        unsigned long rstart = (unsigned long)r->start;
+        unsigned long rend = rstart + r->size;
+        unsigned long start = rstart > lo ? rstart : lo;
+        unsigned long end = rend < hi ? rend : hi;
+        element_t *next = np->next;
+
+        if (start >= end) {
+            /* none of this one is in range */
+            forget_matches(vars, rstart, rend);
+            l_remove(vars->regions, pp, NULL);
+            dropped++;
+            np = next;
+            continue;
+        }
+
+        if (start != rstart || end != rend) {
+            forget_matches(vars, rstart, start);
+            forget_matches(vars, end, rend);
+            r->start = (void *)start;
+            r->size = end - start;
+            cropped++;
+        }
+        else {
+            kept++;
+        }
+
+        pp = np;
+        np = next;
+    }
+
+    if (vars->regions->size == 0)
+        show_warn("nothing is mapped in that range.\n");
+    else
+        show_info("%zu regions left, %zu of them cut down, %zu dropped.\n",
+                  kept + cropped, cropped, dropped);
+
+    return true;
+}
+
 bool handler__lregions(globals_t * vars, char **argv, unsigned argc)
 {
     element_t *np = vars->regions->head;

--- a/handlers.h
+++ b/handlers.h
@@ -159,6 +159,19 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc);
 
 bool handler__lregions(globals_t *vars, char **argv, unsigned argc);
 
+#define RANGE_SHRTDOC "crop the regions list to an address range"
+#define RANGE_LONGDOC "usage: range <start> <end>\n" \
+                "Narrow the regions list down to the addresses between `start` and\n" \
+                "`end`, both hexadecimal and both inclusive of `start`, exclusive of\n" \
+                "`end`. Regions outside the range are dropped, regions crossing an\n" \
+                "edge are cut down to the part inside it, and matches that fall\n" \
+                "outside are removed along with them.\n" \
+                "Useful when you already know roughly where the value lives, since\n" \
+                "the scan then only has to read that much memory. `reset` puts the\n" \
+                "full regions list back.\n"
+
+bool handler__range(globals_t *vars, char **argv, unsigned argc);
+
 #define GREATERTHAN_SHRTDOC "match values that have increased or greater than some number"
 #define LESSTHAN_SHRTDOC    "match values that have decreased or less than some number"
 #define NOTCHANGED_SHRTDOC  "match values that have not changed or equal to some number"

--- a/scanmem.1
+++ b/scanmem.1
@@ -272,6 +272,15 @@ the start address.
 .BR lregions " command.
 
 .TP
+.BI range " start end
+.RI "Crop the regions list to the addresses from " start " up to but not including " end ,
+both hexadecimal. Regions outside are dropped, regions crossing an edge are cut down to the
+part inside, and matches outside go with them. Handy when the value is known to live in a
+particular part of the address space, since the scan then only reads that much memory.
+.br
+.BR reset " puts the full regions list back.
+
+.TP
 .BI option " name value
 Change options at runtime. E.g. the scan data type can be changed.
 See `help option` for all possible names/values.

--- a/scanmem.c
+++ b/scanmem.c
@@ -146,6 +146,8 @@ bool sm_init(void)
                        NULL, DREGION_LONGDOC, NULL);
     sm_registercommand("lregions", handler__lregions, vars->commands,
                        LREGIONS_SHRTDOC, LREGIONS_LONGDOC, NULL);
+    sm_registercommand("range", handler__range, vars->commands,
+                       RANGE_SHRTDOC, RANGE_LONGDOC, NULL);
     sm_registercommand("version", handler__version, vars->commands,
                        VERSION_SHRTDOC, VERSION_LONGDOC, NULL);
     sm_registercommand("=", handler__operators, vars->commands, NOTCHANGED_SHRTDOC,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,7 @@
-TESTS = sm_test.sh
+TESTS = sm_test.sh range_tests.sh
 check_PROGRAMS = memfake
 
 memfake_SOURCES = memfake.c
 memfake_CFLAGS = -std=gnu99 -Wall
+
+EXTRA_DIST = range_tests.sh

--- a/test/range_tests.sh
+++ b/test/range_tests.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# `range` crops the regions list to an address window. The thing worth
+# checking is that cropping does not lose or invent matches: splitting a
+# window in two has to account for exactly the matches the whole window
+# finds, and the parser has to refuse the obvious bad input.
+
+set -u
+
+SM=../scanmem
+fails=0
+
+./memfake 4 0 &
+pid=$!
+trap 'kill $pid 2>/dev/null' EXIT
+sleep 1
+
+sm () {   # run a command list against the target, print everything
+    $SM -p $pid -e -c "$1" 2>&1
+}
+
+matches () {   # count of matches the last scan reported
+    sm "$1" | grep -oE 'we currently have [0-9]+ matches' | tail -1 \
+        | grep -oE '[0-9]+'
+}
+
+check () {   # description, expected, actual
+    if [ "$2" = "$3" ]; then
+        echo "PASS: $1"
+    else
+        echo "FAIL: $1 (expected '$2', got '$3')"
+        fails=$((fails + 1))
+    fi
+}
+
+# scanning needs ptrace, which usually means root. CI runs this under sudo,
+# a plain `make check` does not, so say so and skip instead of failing.
+if sm "option scan_data_type int;0;exit" | grep -q 'failed to attach'; then
+    echo "cannot attach to the target, run this as root (see ptrace_scope)"
+    exit 77
+fi
+
+# the biggest region is memfake's 4MB array, work inside that
+line=$(sm "lregions;exit" | grep -E '^\[ *[0-9]+\]' \
+       | sort -t, -k2 -n -r | head -1)
+start=$(echo "$line" | sed -E 's/^\[ *[0-9]+\] *//; s/,.*//')
+if [ -z "$start" ]; then
+    echo "FAIL: could not find a region to work with"
+    exit 1
+fi
+
+# a 64k window inside it, and its two halves
+lo=$start
+mid=$(printf '%x' $((0x$start + 0x8000)))
+hi=$(printf '%x'  $((0x$start + 0x10000)))
+
+whole=$(matches "range $lo $hi;option scan_data_type int;0;exit")
+first=$(matches "range $lo $mid;option scan_data_type int;0;exit")
+second=$(matches "range $mid $hi;option scan_data_type int;0;exit")
+
+echo "window $lo-$hi: whole=$whole first=$first second=$second"
+if [ -z "$whole" ] || [ -z "$first" ] || [ -z "$second" ]; then
+    echo "FAIL: no match counts came back"
+    exit 1
+fi
+
+# a value spanning the split point belongs to neither half, so the halves
+# can come up short by at most the 3 bytes an int can straddle by
+diff=$((whole - first - second))
+if [ "$diff" -ge 0 ] && [ "$diff" -le 3 ]; then
+    echo "PASS: halves account for the whole window (off by $diff)"
+else
+    echo "FAIL: halves do not add up, whole=$whole first=$first second=$second"
+    fails=$((fails + 1))
+fi
+
+# cropping has to actually crop
+[ "$first" -lt "$whole" ] \
+    && echo "PASS: half the window finds fewer matches" \
+    || { echo "FAIL: half the window found $first, whole found $whole"; fails=$((fails + 1)); }
+
+# a window with nothing mapped in it leaves no regions
+out=$(sm "range 10 20;exit")
+check "empty window warns" "yes" \
+      "$(echo "$out" | grep -q 'nothing is mapped' && echo yes || echo no)"
+
+# and then a scan there finds nothing
+none=$(matches "range 10 20;option scan_data_type int;0;exit")
+check "empty window finds nothing" "0" "${none:-0}"
+
+# bad input
+check "backwards range rejected" "yes" \
+      "$(sm "range $hi $lo;exit" | grep -q 'has to be above' && echo yes || echo no)"
+check "non hex rejected" "yes" \
+      "$(sm "range zz $hi;exit" | grep -q 'bad start address' && echo yes || echo no)"
+check "missing argument rejected" "yes" \
+      "$(sm "range $lo;exit" | grep -q 'expected two addresses' && echo yes || echo no)"
+
+# cropping with matches already on the list has to throw away the ones that
+# fall outside, so a scan then crop then rescan lands on the same count as
+# scanning the cropped window from the start
+cropped_after=$(matches "option scan_data_type int;0;range $lo $mid;=;exit")
+check "cropping an existing match list keeps only what is in range" \
+      "$first" "$cropped_after"
+
+# reset brings the full region list back
+before=$(sm "lregions;exit" | grep -cE '^\[ *[0-9]+\]')
+after=$(sm "range $lo $mid;reset;lregions;exit" | grep -cE '^\[ *[0-9]+\]')
+check "reset restores the regions" "$before" "$after"
+
+echo "---"
+if [ "$fails" -eq 0 ]; then
+    echo "all range tests passed"
+    exit 0
+fi
+echo "$fails range test(s) failed"
+exit 1


### PR DESCRIPTION
Closes #429, and covers #322 as well.

`dregion` can only drop whole regions, so there is no way to say "it is somewhere between 0x500000000 and 0x700000000, only look there". On a large process that is the difference between reading a few hundred MB and reading the lot.

`range <start> <end>` intersects every region with the window. Regions fully outside are dropped, regions crossing an edge are cut down to the part inside, and matches that fall outside go with them so the match list stays consistent with the regions it came from. Both addresses hex, start inclusive, end exclusive, and `reset` puts the full list back.

Offsets in `list` come from load_addr rather than the region start, so cropping does not shift what you see.

For the GUI side of #429 this is the primitive the two text boxes would call.

test/range_tests.sh checks the part that is easy to get wrong. Splitting a 64k window in half has to account for every match the whole window finds:

```
window 7f3817388000-7f3817398000: whole=65533 first=32765 second=32768
```

32765 + 32768 = 65533, the three missing being the ints that straddle the split point. It also checks that cropping an existing match list leaves the same count as scanning the cropped window from scratch, that an unmapped window warns and finds nothing, that reset restores the regions, and that backwards, non hex and missing arguments are refused.

Both halves fail that suite when broken on purpose, the crop and the match deletion separately, so it is not passing vacuously. It skips rather than fails when it cannot ptrace, since a plain `make check` is not root and CI runs it under sudo.

valgrind over scan, crop, rescan, crop to nothing, reset: no errors, no definite leaks. Clean under -Wextra. Man page entry added.
