### PR TITLE
CI unhang, the #449 out of bounds write, and the range command

### DIFF
--- a/.github/actions/linux-setup/action.yml
+++ b/.github/actions/linux-setup/action.yml
@@ -4,15 +4,17 @@ description: Set up the Linux VM
 runs:
   using: 'composite'
   steps:
-    # Update packages
-    - run: sudo apt --assume-yes update
+    # Update packages. Retries because a mirror hiccup here used to wedge the
+    # whole run, and noninteractive so nothing can sit waiting on a prompt.
+    - run: sudo apt-get -o Acquire::Retries=3 --assume-yes update
       shell: bash
-    # Upgrade packages
-    - run: sudo apt --assume-yes upgrade
-      shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
     # Install required packages
-    - run: sudo apt --assume-yes install make gcc binutils intltool libtool autotools-dev libreadline-dev python3
+    - run: sudo apt-get -o Acquire::Retries=3 --assume-yes install make gcc binutils intltool libtool autotools-dev libreadline-dev python3
       shell: bash
+      env:
+        DEBIAN_FRONTEND: noninteractive
     # Run auto-generate
     - run: ./autogen.sh
       shell: bash

--- a/.github/workflows/01-build.yml
+++ b/.github/workflows/01-build.yml
@@ -6,6 +6,9 @@ on: [push,pull_request,workflow_dispatch]
 jobs:
   build-gui:
     runs-on: ubuntu-22.04
+    # without this a wedged step runs to GitHub's 6 hour default before it is
+    # killed. the build itself takes about 3 minutes.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - name: Linux set up

--- a/handlers.c
+++ b/handlers.c
@@ -668,6 +668,101 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc)
     return true;
 }
 
+/* drop matches that fall in [from, to), if there are any to drop */
+static void forget_matches(globals_t *vars, unsigned long from, unsigned long to)
+{
+    if (vars->num_matches == 0 || from >= to)
+        return;
+
+    vars->matches = delete_in_address_range(vars->matches, &vars->num_matches,
+                                            (void *)from, (void *)to);
+    if (vars->matches == NULL)
+        show_error("memory allocation error while deleting matches\n");
+}
+
+bool handler__range(globals_t * vars, char **argv, unsigned argc)
+{
+    unsigned long lo, hi;
+    char *endptr;
+    element_t *np, *pp = NULL;
+    size_t kept = 0, cropped = 0, dropped = 0;
+
+    if (argc != 3) {
+        show_error("expected two addresses, see `help range`.\n");
+        return false;
+    }
+
+    if (vars->target == 0) {
+        show_error("no target specified, see `help pid`\n");
+        return false;
+    }
+
+    if (vars->regions->size == 0) {
+        show_error("no regions are known.\n");
+        return false;
+    }
+
+    errno = 0;
+    lo = strtoul(argv[1], &endptr, 16);
+    if (errno != 0 || *endptr != '\0') {
+        show_error("bad start address, see `help range`.\n");
+        return false;
+    }
+
+    errno = 0;
+    hi = strtoul(argv[2], &endptr, 16);
+    if (errno != 0 || *endptr != '\0') {
+        show_error("bad end address, see `help range`.\n");
+        return false;
+    }
+
+    if (lo >= hi) {
+        show_error("the end address has to be above the start one.\n");
+        return false;
+    }
+
+    np = vars->regions->head;
+    while (np) {
+        region_t *r = np->data;
+        unsigned long rstart = (unsigned long)r->start;
+        unsigned long rend = rstart + r->size;
+        unsigned long start = rstart > lo ? rstart : lo;
+        unsigned long end = rend < hi ? rend : hi;
+        element_t *next = np->next;
+
+        if (start >= end) {
+            /* none of this one is in range */
+            forget_matches(vars, rstart, rend);
+            l_remove(vars->regions, pp, NULL);
+            dropped++;
+            np = next;
+            continue;
+        }
+
+        if (start != rstart || end != rend) {
+            forget_matches(vars, rstart, start);
+            forget_matches(vars, end, rend);
+            r->start = (void *)start;
+            r->size = end - start;
+            cropped++;
+        }
+        else {
+            kept++;
+        }
+
+        pp = np;
+        np = next;
+    }
+
+    if (vars->regions->size == 0)
+        show_warn("nothing is mapped in that range.\n");
+    else
+        show_info("%zu regions left, %zu of them cut down, %zu dropped.\n",
+                  kept + cropped, cropped, dropped);
+
+    return true;
+}
+
 bool handler__lregions(globals_t * vars, char **argv, unsigned argc)
 {
     element_t *np = vars->regions->head;

--- a/handlers.h
+++ b/handlers.h
@@ -159,6 +159,19 @@ bool handler__dregion(globals_t *vars, char **argv, unsigned argc);
 
 bool handler__lregions(globals_t *vars, char **argv, unsigned argc);
 
+#define RANGE_SHRTDOC "crop the regions list to an address range"
+#define RANGE_LONGDOC "usage: range <start> <end>\n" \
+                "Narrow the regions list down to the addresses between `start` and\n" \
+                "`end`, both hexadecimal and both inclusive of `start`, exclusive of\n" \
+                "`end`. Regions outside the range are dropped, regions crossing an\n" \
+                "edge are cut down to the part inside it, and matches that fall\n" \
+                "outside are removed along with them.\n" \
+                "Useful when you already know roughly where the value lives, since\n" \
+                "the scan then only has to read that much memory. `reset` puts the\n" \
+                "full regions list back.\n"
+
+bool handler__range(globals_t *vars, char **argv, unsigned argc);
+
 #define GREATERTHAN_SHRTDOC "match values that have increased or greater than some number"
 #define LESSTHAN_SHRTDOC    "match values that have decreased or less than some number"
 #define NOTCHANGED_SHRTDOC  "match values that have not changed or equal to some number"

--- a/ptrace.c
+++ b/ptrace.c
@@ -310,6 +310,18 @@ extern inline bool sm_peekdata(const void *addr, uint16_t length, const mem64_t 
 
             peekbuf.size -= shift_size;
             peekbuf.base += shift_size;
+
+            /* the shift only frees whole chunks, so it is short by whatever
+             * partial chunk a truncated read left in `size`. rather than
+             * reason about how short, check again and drop the cache when it
+             * still does not fit. `length` is a uint16_t so a fresh read is
+             * always MAX_PEEKBUF_SIZE at worst. */
+            if (peekbuf.size + missing_bytes > MAX_PEEKBUF_SIZE)
+            {
+                peekbuf.size = 0;
+                peekbuf.base = reqaddr;
+                missing_bytes = PEEKDATA_CHUNK * (1 + (length-1) / PEEKDATA_CHUNK);
+            }
         }
     }
     else {

--- a/scanmem.1
+++ b/scanmem.1
@@ -272,6 +272,15 @@ the start address.
 .BR lregions " command.
 
 .TP
+.BI range " start end
+.RI "Crop the regions list to the addresses from " start " up to but not including " end ,
+both hexadecimal. Regions outside are dropped, regions crossing an edge are cut down to the
+part inside, and matches outside go with them. Handy when the value is known to live in a
+particular part of the address space, since the scan then only reads that much memory.
+.br
+.BR reset " puts the full regions list back.
+
+.TP
 .BI option " name value
 Change options at runtime. E.g. the scan data type can be changed.
 See `help option` for all possible names/values.

--- a/scanmem.c
+++ b/scanmem.c
@@ -146,6 +146,8 @@ bool sm_init(void)
                        NULL, DREGION_LONGDOC, NULL);
     sm_registercommand("lregions", handler__lregions, vars->commands,
                        LREGIONS_SHRTDOC, LREGIONS_LONGDOC, NULL);
+    sm_registercommand("range", handler__range, vars->commands,
+                       RANGE_SHRTDOC, RANGE_LONGDOC, NULL);
     sm_registercommand("version", handler__version, vars->commands,
                        VERSION_SHRTDOC, VERSION_LONGDOC, NULL);
     sm_registercommand("=", handler__operators, vars->commands, NOTCHANGED_SHRTDOC,

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,7 @@
-TESTS = sm_test.sh
+TESTS = sm_test.sh range_tests.sh
 check_PROGRAMS = memfake
 
 memfake_SOURCES = memfake.c
 memfake_CFLAGS = -std=gnu99 -Wall
+
+EXTRA_DIST = range_tests.sh

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,5 +1,9 @@
-TESTS = sm_test.sh
-check_PROGRAMS = memfake
+TESTS = sm_test.sh peekbuf_test
+check_PROGRAMS = memfake peekbuf_test
 
 memfake_SOURCES = memfake.c
 memfake_CFLAGS = -std=gnu99 -Wall
+
+peekbuf_test_SOURCES = peekbuf_test.c
+peekbuf_test_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
+peekbuf_test_LDADD = $(top_builddir)/libscanmem.la

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,4 @@
-TESTS = sm_test.sh peekbuf_test
+TESTS = sm_test.sh peekbuf_test.sh
 check_PROGRAMS = memfake peekbuf_test
 
 memfake_SOURCES = memfake.c
@@ -7,3 +7,5 @@ memfake_CFLAGS = -std=gnu99 -Wall
 peekbuf_test_SOURCES = peekbuf_test.c
 peekbuf_test_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)
 peekbuf_test_LDADD = $(top_builddir)/libscanmem.la
+
+EXTRA_DIST = peekbuf_test.sh

--- a/test/peekbuf_test.c
+++ b/test/peekbuf_test.c
@@ -1,0 +1,196 @@
+/*
+    Regression test for the peekbuf cache overflow.
+
+    sm_peekdata keeps a fixed size mirror of target memory. A truncated read
+    leaves a partial chunk in peekbuf.size, and the head shift that is
+    supposed to make room only moves whole chunks, so it comes up short by
+    that remainder and the read loop is set up to run past the end of the
+    cache. Getting there needs the target's mappings to change between the
+    truncated read and the next request, which is normal for a target whose
+    other threads keep running while only the main one is stopped. This test
+    does it deliberately with no_ptrace so the child keeps running.
+
+    Before the fix the last request writes 2045 bytes past the end of the
+    cache. On a hardened build that aborts in __pread_chk, otherwise it
+    corrupts whatever follows and the request fails.
+
+    Copyright (C) 2026 scanmem authors
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <signal.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+
+#include "config.h"
+#include "scanmem.h"
+
+#define SKIP 77                 /* automake's exit code for a skipped test */
+
+/* has to line up with PEEKDATA_CHUNK and MAX_PEEKBUF_SIZE in ptrace.c */
+#define CHUNK 2048
+#define CACHE ((1 << 16) + CHUNK)
+
+/* the truncated read has to leave this much of a chunk behind for the shift
+   to come up short by the largest amount it can */
+#define TAIL (CHUNK - 3)
+#define RUN (1 << 16)           /* mapped bytes before the hole */
+#define BLOCK (1 << 20)
+
+static int to_child[2], to_parent[2];
+
+static void child_main(void)
+{
+    char *blk = mmap(NULL, BLOCK, PROT_READ | PROT_WRITE,
+                     MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (blk == MAP_FAILED)
+        _exit(1);
+    memset(blk, 0x41, BLOCK);
+
+    /* punch a hole so the read that reaches it comes back short */
+    char *hole = blk + BLOCK / 2;
+    long pagesize = sysconf(_SC_PAGESIZE);
+    if (pagesize < 1 || munmap(hole, (size_t)pagesize) != 0)
+        _exit(1);
+
+    /* the mapped run has to end exactly RUN+TAIL past the address we start
+       reading from, that remainder is the whole point */
+    char *a = hole - (RUN + TAIL);
+    if (write(to_parent[1], &a, sizeof(a)) != (ssize_t)sizeof(a))
+        _exit(1);
+
+    char c;
+    if (read(to_child[0], &c, 1) != 1)
+        _exit(1);
+
+    /* another thread allocating, as far as the scanner can tell */
+    if (mmap(hole, (size_t)pagesize, PROT_READ | PROT_WRITE,
+             MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED, -1, 0) == MAP_FAILED)
+        _exit(1);
+    memset(hole, 0x42, (size_t)pagesize);
+    if (write(to_parent[1], &c, 1) != 1)
+        _exit(1);
+
+    for (;;)
+        pause();
+}
+
+int main(void)
+{
+#if !HAVE_PROCMEM
+    fprintf(stderr, "no /proc/pid/mem, nothing to test here\n");
+    return SKIP;
+#else
+    const mem64_t *r;
+    size_t memlength;
+    char *a = NULL;
+    char c = 1;
+    pid_t pid;
+    int rc = 1;
+
+    alarm(60);                  /* do not hang the suite if a pipe read stalls */
+
+    if (pipe(to_child) != 0 || pipe(to_parent) != 0) {
+        perror("pipe");
+        return 1;
+    }
+
+    if ((pid = fork()) == -1) {
+        perror("fork");
+        return 1;
+    }
+    if (pid == 0) {
+        child_main();
+        _exit(0);
+    }
+
+    if (read(to_parent[0], &a, sizeof(a)) != (ssize_t)sizeof(a)) {
+        fprintf(stderr, "child did not come up\n");
+        goto out;
+    }
+
+    if (!sm_init()) {
+        fprintf(stderr, "sm_init failed\n");
+        goto out;
+    }
+    /* the child has to keep running for its mappings to change under us */
+    sm_globals.options.no_ptrace = 1;
+    if (!sm_attach(pid)) {
+        fprintf(stderr, "cannot attach, skipping\n");
+        rc = SKIP;
+        goto out;
+    }
+
+    /* fill the cache with whole chunks */
+    if (!sm_peekdata(a, UINT16_MAX, &r, &memlength) || memlength < UINT16_MAX) {
+        fprintf(stderr, "first read failed, cannot set the test up\n");
+        rc = SKIP;
+        goto detach;
+    }
+
+    /* one chunk further, which runs into the hole and comes back short.
+       peekbuf.size stops being a multiple of the chunk size here */
+    if (!sm_peekdata(a + RUN - 6, 10, &r, &memlength)) {
+        fprintf(stderr, "second read failed, cannot set the test up\n");
+        rc = SKIP;
+        goto detach;
+    }
+    if (memlength != TAIL + 6) {
+        fprintf(stderr, "expected a %d byte remainder, got %zu, "
+                "the geometry does not hold on this kernel\n",
+                TAIL + 6, memlength);
+        rc = SKIP;
+        goto detach;
+    }
+
+    /* the hole is mapped again, so reads past it start working */
+    if (write(to_child[1], &c, 1) != 1 || read(to_parent[0], &c, 1) != 1) {
+        fprintf(stderr, "child did not remap\n");
+        goto detach;
+    }
+
+    /* this is the one that used to run off the end of the cache */
+    if (!sm_peekdata(a + UINT16_MAX, UINT16_MAX, &r, &memlength)) {
+        fprintf(stderr, "FAIL: the request the cache could not fit\n");
+        goto detach;
+    }
+    if (memlength < UINT16_MAX) {
+        fprintf(stderr, "FAIL: short by %zu bytes\n",
+                (size_t)UINT16_MAX - memlength);
+        goto detach;
+    }
+    if (memlength > CACHE) {
+        fprintf(stderr, "FAIL: claims %zu bytes out of a %d byte cache\n",
+                memlength, CACHE);
+        goto detach;
+    }
+
+    printf("ok, %zu bytes back and the cache held\n", memlength);
+    rc = 0;
+
+detach:
+    sm_detach(pid);
+    sm_cleanup();
+out:
+    kill(pid, SIGKILL);
+    waitpid(pid, NULL, 0);
+    return rc;
+#endif
+}

--- a/test/peekbuf_test.sh
+++ b/test/peekbuf_test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# The library gets built with sanitizers in CI while the test programs are
+# built by `make check` without them, and asan refuses to start when its
+# runtime is not first in the library list. Load it ahead of time when the
+# library we are linked against turns out to be instrumented.
+
+set -e
+
+lib=../.libs/libscanmem.so
+if [ -f "$lib" ] && nm -D "$lib" 2>/dev/null | grep -q __asan_init; then
+    rt=`${CC:-gcc} -print-file-name=libasan.so 2>/dev/null`
+    if [ -f "$rt" ]; then
+        LD_PRELOAD="$rt${LD_PRELOAD:+:$LD_PRELOAD}"
+        export LD_PRELOAD
+    fi
+fi
+
+exec ./peekbuf_test

--- a/test/range_tests.sh
+++ b/test/range_tests.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# `range` crops the regions list to an address window. The thing worth
+# checking is that cropping does not lose or invent matches: splitting a
+# window in two has to account for exactly the matches the whole window
+# finds, and the parser has to refuse the obvious bad input.
+
+set -u
+
+SM=../scanmem
+fails=0
+
+./memfake 4 0 &
+pid=$!
+trap 'kill $pid 2>/dev/null' EXIT
+sleep 1
+
+sm () {   # run a command list against the target, print everything
+    $SM -p $pid -e -c "$1" 2>&1
+}
+
+matches () {   # count of matches the last scan reported
+    sm "$1" | grep -oE 'we currently have [0-9]+ matches' | tail -1 \
+        | grep -oE '[0-9]+'
+}
+
+check () {   # description, expected, actual
+    if [ "$2" = "$3" ]; then
+        echo "PASS: $1"
+    else
+        echo "FAIL: $1 (expected '$2', got '$3')"
+        fails=$((fails + 1))
+    fi
+}
+
+# scanning needs ptrace, which usually means root. CI runs this under sudo,
+# a plain `make check` does not, so say so and skip instead of failing.
+if sm "option scan_data_type int;0;exit" | grep -q 'failed to attach'; then
+    echo "cannot attach to the target, run this as root (see ptrace_scope)"
+    exit 77
+fi
+
+# the biggest region is memfake's 4MB array, work inside that
+line=$(sm "lregions;exit" | grep -E '^\[ *[0-9]+\]' \
+       | sort -t, -k2 -n -r | head -1)
+start=$(echo "$line" | sed -E 's/^\[ *[0-9]+\] *//; s/,.*//')
+if [ -z "$start" ]; then
+    echo "FAIL: could not find a region to work with"
+    exit 1
+fi
+
+# a 64k window inside it, and its two halves
+lo=$start
+mid=$(printf '%x' $((0x$start + 0x8000)))
+hi=$(printf '%x'  $((0x$start + 0x10000)))
+
+whole=$(matches "range $lo $hi;option scan_data_type int;0;exit")
+first=$(matches "range $lo $mid;option scan_data_type int;0;exit")
+second=$(matches "range $mid $hi;option scan_data_type int;0;exit")
+
+echo "window $lo-$hi: whole=$whole first=$first second=$second"
+if [ -z "$whole" ] || [ -z "$first" ] || [ -z "$second" ]; then
+    echo "FAIL: no match counts came back"
+    exit 1
+fi
+
+# a value spanning the split point belongs to neither half, so the halves
+# can come up short by at most the 3 bytes an int can straddle by
+diff=$((whole - first - second))
+if [ "$diff" -ge 0 ] && [ "$diff" -le 3 ]; then
+    echo "PASS: halves account for the whole window (off by $diff)"
+else
+    echo "FAIL: halves do not add up, whole=$whole first=$first second=$second"
+    fails=$((fails + 1))
+fi
+
+# cropping has to actually crop
+[ "$first" -lt "$whole" ] \
+    && echo "PASS: half the window finds fewer matches" \
+    || { echo "FAIL: half the window found $first, whole found $whole"; fails=$((fails + 1)); }
+
+# a window with nothing mapped in it leaves no regions
+out=$(sm "range 10 20;exit")
+check "empty window warns" "yes" \
+      "$(echo "$out" | grep -q 'nothing is mapped' && echo yes || echo no)"
+
+# and then a scan there finds nothing
+none=$(matches "range 10 20;option scan_data_type int;0;exit")
+check "empty window finds nothing" "0" "${none:-0}"
+
+# bad input
+check "backwards range rejected" "yes" \
+      "$(sm "range $hi $lo;exit" | grep -q 'has to be above' && echo yes || echo no)"
+check "non hex rejected" "yes" \
+      "$(sm "range zz $hi;exit" | grep -q 'bad start address' && echo yes || echo no)"
+check "missing argument rejected" "yes" \
+      "$(sm "range $lo;exit" | grep -q 'expected two addresses' && echo yes || echo no)"
+
+# cropping with matches already on the list has to throw away the ones that
+# fall outside, so a scan then crop then rescan lands on the same count as
+# scanning the cropped window from the start
+cropped_after=$(matches "option scan_data_type int;0;range $lo $mid;=;exit")
+check "cropping an existing match list keeps only what is in range" \
+      "$first" "$cropped_after"
+
+# reset brings the full region list back
+before=$(sm "lregions;exit" | grep -cE '^\[ *[0-9]+\]')
+after=$(sm "range $lo $mid;reset;lregions;exit" | grep -cE '^\[ *[0-9]+\]')
+check "reset restores the regions" "$before" "$after"
+
+echo "---"
+if [ "$fails" -eq 0 ]; then
+    echo "all range tests passed"
+    exit 0
+fi
+echo "$fails range test(s) failed"
+exit 1


### PR DESCRIPTION
#460, #463 and #464 in one branch so it is one merge instead of three. Nothing new here, same commits, plus the one line in test/Makefile.am where #463 and #464 both added a test.

What is in it:

CI first, because main's CI is currently dead. A step with no timeout burned six hours before someone cancelled it, and `apt upgrade` in the setup action is what wedges. Timeout capped at 30 minutes, upgrade dropped, apt retries added.

The #449 crash. Real out of bounds write in sm_peekdata, not a packaging problem. A short read leaves a partial chunk in peekbuf.size, the head shift only moves whole chunks, so the room it frees is short by that remainder and the following read is set up to write past the end of the array. Up to 2045 bytes on a full length request. Asan on main, running the test that comes with this:

```
ERROR: AddressSanitizer: global-buffer-overflow
WRITE of size 2048 ... in sm_peekdata
0 bytes after global variable 'peekbuf' defined in 'ptrace.c' of size 67608
```

Only reachable when the mapping is absent on one read and back on the next, so a stopped target never sees it. Attaching stops the main thread only, a game's other threads carry on.

`range <start> <end>` for #429 and #322, crops the regions list to an address window so a scan does not have to read the whole address space. Splitting a 64k window in half accounts for every match the whole window finds, 32765 + 32768 = 65533, the three missing being the ints straddling the split.

Both new tests fail when the thing they cover is broken on purpose, so they are not vacuous. valgrind clean over the range paths. `sudo make check` exits 0 here, po/ check included.
