### PR TITLE
Add a .clang-format for the C sources

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,14 @@
+# scanmem house style. LLVM base with the project's long-standing deviations.
+# Note: the tree predates any formatter and hand-aligns trailing comments, so
+# running clang-format across all existing files produces a large diff. This
+# config is for formatting new and changed code to match, not a mass reformat.
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 0
+BreakBeforeBraces: Linux
+PointerAlignment: Right
+SortIncludes: false
+SpaceAfterCStyleCast: true
+IndentPPDirectives: AfterHash


### PR DESCRIPTION
You asked for a .clang-format in its own PR, here it is.

It is LLVM base plus the deviations the tree already uses: 4-space indent, no
tabs, function braces on their own line with control braces attached (Linux),
pointer to the right, no include sorting since includes are ordered by hand, a
space after C-style casts, and AfterHash preprocessor indentation.

One honest caveat: the tree predates any formatter and hand-aligns trailing
comments across a column, which clang-format cannot preserve. So running it over
the existing files produces a big diff (~3000 lines) that is mostly comment
re-alignment, not real style changes. I set ColumnLimit 0 so it will not rewrap
lines, but the comment alignment is unavoidable. That is why this is scoped as
a going-forward config for new and changed code, not a mass reformat. Whether to
ever reformat the whole tree is a separate call, happy to do it if you want it.
