### PR TITLE
Accept unsigned integer types in the write command (#359)

### DIFF
--- a/handlers.c
+++ b/handlers.c
@@ -1481,6 +1481,27 @@ static inline scan_data_type_t parse_scan_data_type(const char *str)
     return (scan_data_type_t)(-1);
 }
 
+/* recognize unsigned integer type names for `write`. returns the byte width
+ * and sets *fmt, or 0 if str is not an unsigned int type. scan types don't
+ * carry sign (it's a match flag), but a write has to parse the value with the
+ * right signedness or values above the signed max get rejected (#359). */
+static inline int parse_write_uint_type(const char *str, const char **fmt)
+{
+    if ((strcasecmp(str, "u8") == 0)  || (strcasecmp(str, "uint8") == 0)  ||
+        (strcasecmp(str, "uinteger8") == 0))
+        { *fmt = "%"PRIu8;  return 1; }
+    if ((strcasecmp(str, "u16") == 0) || (strcasecmp(str, "uint16") == 0) ||
+        (strcasecmp(str, "uinteger16") == 0))
+        { *fmt = "%"PRIu16; return 2; }
+    if ((strcasecmp(str, "u32") == 0) || (strcasecmp(str, "uint32") == 0) ||
+        (strcasecmp(str, "uinteger32") == 0))
+        { *fmt = "%"PRIu32; return 4; }
+    if ((strcasecmp(str, "u64") == 0) || (strcasecmp(str, "uint64") == 0) ||
+        (strcasecmp(str, "uinteger64") == 0))
+        { *fmt = "%"PRIu64; return 8; }
+    return 0;
+}
+
 /* write value_type address value */
 bool handler__write(globals_t * vars, char **argv, unsigned argc)
 {
@@ -1502,8 +1523,17 @@ bool handler__write(globals_t * vars, char **argv, unsigned argc)
 
     scan_data_type_t st = parse_scan_data_type(argv[1]);
 
+    /* unsigned ints come in from GC (write uint8 addr val) and the CLI. they
+     * aren't scan types, so parse the width/format here before the signed set. */
+    int uwidth = parse_write_uint_type(argv[1], &fmt);
+
     /* try int first */
-    if (st == INTEGER8)
+    if (uwidth > 0)
+    {
+        data_width = uwidth;
+        datatype = 0;
+    }
+    else if (st == INTEGER8)
     {
         data_width = 1;
         datatype = 0;

--- a/handlers.h
+++ b/handlers.h
@@ -311,13 +311,14 @@ bool handler__show(globals_t *vars, char **argv, unsigned argc);
 bool handler__dump(globals_t *vars, char **argv, unsigned argc);
 
 #define VALUE_TYPES "int8,int16,int32,int64,float32,float64,bytearray,string"
-#define WRITE_COMPLETE VALUE_TYPES
+#define WRITE_COMPLETE VALUE_TYPES ",uint8,uint16,uint32,uint64"
 #define WRITE_SHRTDOC "change the value of a specific memory location"
 #define WRITE_LONGDOC "usage: write <value_type> <address> <value>\n" \
                 "\n" \
                 "Write <value> into <address>\n" \
                 "<value_type> should be one of:\n" \
                 "\tint{8|16|32|64} (or i{8|16|32|64} for short)\n" \
+                "\tuint{8|16|32|64} (or u{8|16|32|64} for short)\n" \
                 "\tfloat{32|64} (or f{32|64} for short)\n" \
                 "\tbytearray\n" \
                 "\tstring\n" \

--- a/test/sm_test.sh
+++ b/test/sm_test.sh
@@ -32,5 +32,17 @@ done
 test_sm "option scan_data_type bytearray;${huge_bytearray};exit"
 test_sm "option scan_data_type string;\" ${huge_string};exit"
 
+# Unsigned integer writes (#359). uint8/16/32/64 used to be rejected as a bad
+# data_type, so a value shown as unsigned in GameConqueror never got written.
+# Write through the first writable anonymous mapping of the target; under -e a
+# rejected type or a failed write aborts the test.
+uaddr=$(awk '$2 ~ /rw-p/ && $6=="" {print $1; exit}' /proc/$memfake_pid/maps | cut -d- -f1)
+test -n "$uaddr"
+test_sm "write uint8 0x$uaddr 200"
+test_sm "write uint16 0x$uaddr 60000"
+test_sm "write uint32 0x$uaddr 4000000000"
+test_sm "write uint64 0x$uaddr 18000000000000000000"
+test_sm "write u8 0x$uaddr 255"
+
 # Clean up
 kill $memfake_pid


### PR DESCRIPTION
Fixes #359. GameConqueror issues `write uint8 <addr> <val>` (and the other uint widths) whenever a value is shown as unsigned, but the write handler only knew the signed type names. parse_scan_data_type returned -1, the write was rejected as a bad data_type, and the GUI silently reverted the cell. That is the "changing type to uint8 stops accepting new values" bug.

This is your call from the issue: add the unsigned types to libsm's write handler rather than have GC convert back to signed. So the write path now accepts uint8/16/32/64 (plus u8/uinteger8 style aliases). They are only added to the write path, not to scan types, since scanning already carries sign as a match flag and `option scan_data_type` does not take an unsigned type. The unsigned format also parses uint64 values above INT64_MAX, which the signed format clamps.

Also extends the write tab-completion and `help write` text, and adds a sm_test.sh case that writes each unsigned width to a live target.

Verified end to end (couldn't use the box's sudo path so I attached to a throwaway PR_SET_PTRACER target as my own user):

```
write uint8  -> C8              (200)
write uint16 -> 60 EA           (60000, LE)
write uint32 -> 00 28 6B EE     (4000000000, LE)
write uint64 / u8 255 -> accepted, exit 0
```

Builds clean, no new warnings. The suite case will exercise the real ptrace round-trip under CI's sudo.
